### PR TITLE
Corrected reading of Matrix Market sizes and added tests

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/io/MatrixVectorReader.java
+++ b/src/main/java/no/uib/cipr/matrix/io/MatrixVectorReader.java
@@ -259,7 +259,6 @@ public class MatrixVectorReader extends BufferedReader {
     public MatrixSize readMatrixSize(MatrixInfo info) throws IOException {
         // Always read the matrix size
         int numRows = getInt(), numColumns = getInt();
-        int size = getInt();
 
         // For coordinate matrices we also read the number of entries
         if (info.isDense())

--- a/src/test/java/no/uib/cipr/matrix/io/MatrixVectorIoTest.java
+++ b/src/test/java/no/uib/cipr/matrix/io/MatrixVectorIoTest.java
@@ -4,6 +4,7 @@ import junit.framework.TestCase;
 import no.uib.cipr.matrix.DenseMatrix;
 import no.uib.cipr.matrix.Matrix;
 import no.uib.cipr.matrix.MatrixTestAbstract;
+import no.uib.cipr.matrix.sparse.CompRowMatrix;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -17,12 +18,62 @@ public class MatrixVectorIoTest extends TestCase {
     File matrixFile = new File("TestMatrixFile");
     BufferedWriter out = new BufferedWriter(new FileWriter(matrixFile));
     MatrixVectorWriter writer = new MatrixVectorWriter(out);
-    writer.printMatrixInfo(new MatrixInfo(false, MatrixInfo.MatrixField.Real, MatrixInfo.MatrixSymmetry.General));
-    writer.printMatrixSize(new MatrixSize(mat.numRows(), mat.numColumns(), mat.numColumns() * mat.numRows()));
+    MatrixInfo mi = new MatrixInfo(false, MatrixInfo.MatrixField.Real, MatrixInfo.MatrixSymmetry.General);
+    writer.printMatrixInfo(mi);
+    writer.printMatrixSize(new MatrixSize(mat.numRows(), mat.numColumns(), mat.numColumns() * mat.numRows()), mi);
     writer.printArray(mat.getData());
     writer.close();
     Matrix newMat = new DenseMatrix(new MatrixVectorReader(new FileReader(matrixFile)));
 
     MatrixTestAbstract.assertEquals(mat, newMat);
   }
+  
+  public void testSparseWriteRead() throws Exception {
+	  CompRowMatrix mat = new CompRowMatrix(3, 3, new int[][] {
+			  { 1, 2 },
+			  { 0, 2 },
+			  { 1 }
+	  });
+	  mat.set(0, 1, 1);
+	  mat.set(0, 2, 2);
+	  mat.set(1, 0, 3);
+	  mat.set(1, 2, 4);
+	  mat.set(2, 1, 5);
+	  File testFile = new File("TestMatrixFile");
+	  BufferedWriter out = new BufferedWriter(new FileWriter(testFile));
+	  MatrixVectorWriter writer = new MatrixVectorWriter(out);
+	  MatrixInfo mi = new MatrixInfo(true, MatrixInfo.MatrixField.Real, MatrixInfo.MatrixSymmetry.General);
+	  writer.printMatrixInfo(mi);
+	  writer.printMatrixSize(new MatrixSize(mat.numColumns(), mat.numColumns(), mat.getData().length), mi);
+	  int[] rows = buildRowArray(mat);
+	  writer.printCoordinate(rows, mat.getColumnIndices(), mat.getData(), 1);
+	  out.close();
+	  CompRowMatrix newMat = new CompRowMatrix(new MatrixVectorReader(new FileReader(testFile)));
+	  MatrixTestAbstract.assertEquals(mat, newMat);
+  }
+
+private int[] buildRowArray(CompRowMatrix mat) {
+	int[] rows = new int[mat.getData().length];
+	  int curRow = -1;
+	  int nextValidRow = 0;
+	  int curIndex = 0;
+	  int[] rowPs = mat.getRowPointers();
+	  // find first valid row
+	  while(nextValidRow < mat.numRows() && rowPs[nextValidRow] < 0) nextValidRow++; 
+	  while (true) {
+		  curRow = nextValidRow;
+		  nextValidRow++;
+		  while(nextValidRow < mat.numRows() && rowPs[nextValidRow] < 0) nextValidRow++; 
+		  // enter the remainder of data as currentRow		
+		  if(nextValidRow >= mat.numRows()) {
+			  while(curIndex < mat.getData().length)
+				  rows[curIndex++] = curRow;
+			  break;
+		  }
+		  int nextRowIndex = rowPs[nextValidRow];
+		  while(curIndex < nextRowIndex)
+			  rows[curIndex++] = curRow;
+	  }
+	return rows;
+}
 }


### PR DESCRIPTION
MatrixVectorReader reads an additional integer that isn't in the spec

MatrixVectorIOTest writes out the test Dense Matrix using the default printMatrixSize. However calling this without MatrixInfo causes it to assume the matrix is a sparse matrix. As a result of this, the entry count is also printed when it shouldn't.

This patch fixes these two issues and additionally provides a test for Sparse Matrices of the CompRowMatrix form
