### PR TITLE
Fixed issue where SparseVector can allocate more than "size" space

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/sparse/SparseVector.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/SparseVector.java
@@ -202,6 +202,9 @@ public class SparseVector extends AbstractVector implements ISparseVector {
 
             // If zero-length, use new length of 1, else double the bandwidth
             int newLength = data.length != 0 ? data.length << 1 : 1;
+            
+            // Enforce the maximum size.
+            newLength = Math.min(newLength, this.size);
 
             // Copy existing data into new arrays
             newIndex = new int[newLength];

--- a/src/test/java/no/uib/cipr/matrix/sparse/SparseVectorTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/SparseVectorTest.java
@@ -97,4 +97,24 @@ public class SparseVectorTest extends VectorTestAbstract {
             assertTrue(tfVector[index]== value);
         }
 	}
+    
+    /**
+     * Unit test checking that the sparse vector does not end up ever using 
+     * more than "size" elements.
+     */
+	public void testOverAllocation() {
+        for (int d = 0; d < 10; d++) {
+            SparseVector v = new SparseVector(d, 0);
+            assertEquals(0, v.index.length);
+            assertEquals(0, v.data.length);
+
+            // Fill with non-zero elements.
+            for (int i = 0; i < d; i++) {
+                v.set(i, 1.0 + i);
+            }
+
+            assertEquals(d, v.index.length);
+            assertEquals(d, v.data.length);
+        }
+	}
 }


### PR DESCRIPTION
Fixed issue where SparseVector can allocate more than "size" space in its underlying arrays because it was always allocating to a power of 2.

Simply enforce the maximum size when computing the new size.
