### PR TITLE
Fix ILUT bug.

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/sparse/ILUT.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/ILUT.java
@@ -195,7 +195,9 @@ public class ILUT implements Preconditioner {
             gather(LUi, rowi, taui, i);
 
             // Update diagonal index on row i if it is outdated
-            if (rowi.getIndex()[diagind[i]] != i) {
+            int diagIndex = diagind[i];
+            int[] rowiIndices = rowi.getIndex();
+            if (diagIndex >= rowiIndices.length || rowiIndices[diagIndex] != i) {
                 diagind[i] = findDiagonalIndex(rowi, i);
                 if (diagind[i] < 0)
                     throw new RuntimeException("Missing diagonal entry on row "


### PR DESCRIPTION
Fixes bug in ILUT where the old diagind value was used to access the
SparseVector pointer array after tau dropping and compaction, resulting
in an ArrayOutOfBounds Exception.