### PR TITLE
Added method to get the raw indices from a SparseVector

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/sparse/SparseVector.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/SparseVector.java
@@ -311,14 +311,20 @@ public class SparseVector extends AbstractVector implements ISparseVector {
     }
 
     /**
-     * Returns the internal data
+     * Returns the internal value array. This array may contain extra elements
+     * beyond the number that are used. If it is greater than the number used,
+     * the remaining values will be 0. Since this vector can resize its internal
+     * data, if it is modified, this array may no longer represent the internal
+     * state.
+     * 
+     * @return The internal array of values.
      */
     public double[] getData() {
         return data;
     }
 
     /**
-     * Returns the indices
+     * Returns the used indices
      */
     public int[] getIndex() {
         if (used == index.length)
@@ -327,10 +333,23 @@ public class SparseVector extends AbstractVector implements ISparseVector {
         // could run compact, or return subarray
         // compact();
         int[] indices = new int[used];
-        for (int i = 0; i < used; i++) {
-            indices[i] = index[i];
-        }
+        System.arraycopy(index, 0, indices, 0, used);
         return indices;
+    }
+
+    /**
+     * Gets the raw internal index array. This array may contain extra elements
+     * beyond the number that are used. If it is greater than the number used,
+     * the remaining indices will be 0. Since this vector can resize its
+     * internal data, if it is modified, this array may no longer represent the
+     * internal state.
+     * 
+     * @return The internal array of indices, whose length is greater than or
+     *         equal to the number of used elements. Indices in the array beyond
+     *         the used elements are not valid indices since they are unused.
+     */
+    public int[] getRawIndex() {
+        return index;
     }
 
     /**

--- a/src/test/java/no/uib/cipr/matrix/sparse/SparseVectorTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/SparseVectorTest.java
@@ -117,4 +117,26 @@ public class SparseVectorTest extends VectorTestAbstract {
             assertEquals(d, v.data.length);
         }
     }
+
+    public void testGetRawIndex() {
+        SparseVector vector = new SparseVector(Integer.MAX_VALUE);
+        int[] index = vector.getRawIndex();
+        assertTrue(index != null);
+        assertTrue(index.length == 0);
+        assertSame(index, vector.index);
+        assertEquals(index.length, vector.getData().length);
+
+        vector.set(2, 1.0);
+        vector.set(1, 0.0);
+        vector.set(4, 2.0);
+
+        index = vector.getRawIndex();
+        assertSame(index, vector.index);
+        assertEquals(index.length, vector.getData().length);
+
+        // In this case, the raw index is larger than the used, so the raw
+        // indices have more entries than the other one.
+        assertTrue(index.length > vector.getUsed());
+        assertTrue(index.length > vector.getIndex().length);
+    }
 }


### PR DESCRIPTION
In order to avoid potential copying when calling getIndex(), adding a method called getRawIndex() to retrieve the raw, uncompacted indices in the vector. This is meant to mirror the array size returned by getData (which currently may or may not have the same size as getIndex()) and used to support heavily optimized code. It is the case that getting these indices could be dangerous if the underlying vector is modified, but so is the result of getData(), so it is just bringing it in line with the behavior of that call.