### PR TITLE
Fixed typo in CompColMatrix constructor javadocs.

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/sparse/CompColMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/CompColMatrix.java
@@ -153,7 +153,7 @@ public class CompColMatrix extends AbstractMatrix {
      * @param numColumns
      *            Number of columns
      * @param nz
-     *            The nonzero column indices on each column
+     *            The nonzero row indices on each column
      */
     public CompColMatrix(int numRows, int numColumns, int[][] nz) {
         super(numRows, numColumns);


### PR DESCRIPTION
Fixed a typo in the javadoc comment of one of the CompColMatrix constructors.  Since this is a compressed column storage matrix, the "nz" parameter should contain the nonzero *row* indices on each column.