### PR TITLE
should probably have at least a 1x1 matrix

### DIFF
--- a/src/test/java/no/uib/cipr/matrix/SymmEigenvalueTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmEigenvalueTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -46,7 +46,7 @@ public abstract class SymmEigenvalueTestAbstract extends TestCase {
 
     @Override
     protected void setUp() throws Exception {
-        int n = Utilities.getInt(max);
+        int n = Utilities.getInt(1, max);
         A = Matrices.random(n, n);
     }
 


### PR DESCRIPTION
should probably have at least a 1x1 matrix. If we want to test for 0x0 matrix we should do that separately.

The error we saw earlier had to do with the parent test class, SymmEigenvalueTestAbstract, initializing a random 0x0 matrix, A. We were then using the number of rows in A to generate a random int, which threw the exception.

By ensuring that A is at least 1x1 we should avoid random.nextInt(0) problem.