### PR TITLE
Junit4 Upgrade

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/sparse/CompRowMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/CompRowMatrix.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,24 +20,15 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
-import no.uib.cipr.matrix.AbstractMatrix;
-import no.uib.cipr.matrix.DenseVector;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.MatrixEntry;
+import no.uib.cipr.matrix.*;
 import no.uib.cipr.matrix.Vector;
 import no.uib.cipr.matrix.io.MatrixInfo;
 import no.uib.cipr.matrix.io.MatrixSize;
 import no.uib.cipr.matrix.io.MatrixVectorReader;
 
-import com.github.fommil.netlib.BLAS;
+import java.io.IOException;
+import java.util.*;
+import java.util.Arrays;
 
 /**
  * Compressed row storage (CRS) matrix

--- a/src/test/java/no/uib/cipr/matrix/BandCholeskyTest.java
+++ b/src/test/java/no/uib/cipr/matrix/BandCholeskyTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,18 +20,16 @@
 
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
-import no.uib.cipr.matrix.BandCholesky;
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.LowerSPDBandMatrix;
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.UpperSPDBandMatrix;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the banded Cholesky decomposition
  */
-public class BandCholeskyTest extends TestCase {
+public class BandCholeskyTest {
 
     private LowerSPDBandMatrix L;
 
@@ -43,12 +41,8 @@ public class BandCholeskyTest extends TestCase {
 
     private final int max = 100, bmax = 10;
 
-    public BandCholeskyTest(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
 
         kl = Math.min(n, Utilities.getInt(bmax));
@@ -69,13 +63,14 @@ public class BandCholeskyTest extends TestCase {
         I = Matrices.identity(n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         L = null;
         U = null;
         I = null;
     }
 
+    @Test
     public void testLowerBandCholesky() {
         int n = L.numRows();
 
@@ -93,6 +88,7 @@ public class BandCholeskyTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testUpperBandCholesky() {
         int n = U.numRows();
 
@@ -110,6 +106,7 @@ public class BandCholeskyTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testLowerBandCholeskyrcond() {
         int n = L.numRows();
 
@@ -119,6 +116,7 @@ public class BandCholeskyTest extends TestCase {
         c.rcond(L);
     }
 
+    @Test
     public void testUpperBandCholeskyrcond() {
         int n = U.numRows();
 

--- a/src/test/java/no/uib/cipr/matrix/BandLUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/BandLUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,16 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.BandLU;
-import no.uib.cipr.matrix.BandMatrix;
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.Matrix;
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the banded LU decomposition
  */
-public class BandLUTest extends TestCase {
+public class BandLUTest {
 
     private BandMatrix A;
 
@@ -40,12 +39,8 @@ public class BandLUTest extends TestCase {
 
     private final int max = 100, bmax = 10;
 
-    public BandLUTest(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
         kl = Math.min(n, Utilities.getInt(bmax));
         ku = Math.min(n, Utilities.getInt(bmax));
@@ -58,12 +53,13 @@ public class BandLUTest extends TestCase {
         I = Matrices.identity(n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         A = null;
         I = null;
     }
 
+    @Test
     public void testBandLU() {
         int n = A.numRows();
 
@@ -81,6 +77,7 @@ public class BandLUTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testBandLUtranspose() {
         int n = A.numRows();
 
@@ -98,6 +95,7 @@ public class BandLUTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testBandLUrcond() {
         int n = A.numRows();
 

--- a/src/test/java/no/uib/cipr/matrix/BandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/BandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,12 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.BandMatrix;
+import org.junit.Test;
 
 /**
  * Test of BandMatrix
  */
 public class BandMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public BandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {
@@ -40,6 +36,7 @@ public class BandMatrixTest extends StructImmutableMatrixTestAbstract {
         Ad = Utilities.bandPopulate(A, kl, ku);
     }
 
+    @Test
     @Override
     public void testTransposeInplace() {
         BandMatrix B = (BandMatrix) A;
@@ -47,11 +44,13 @@ public class BandMatrixTest extends StructImmutableMatrixTestAbstract {
             super.testTransposeInplace();
     }
 
+    @Test
     @Override
     public void testTransMatrixSolve() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testTransVectorSolve() {
         // Not supported

--- a/src/test/java/no/uib/cipr/matrix/DenseCholeskyTest.java
+++ b/src/test/java/no/uib/cipr/matrix/DenseCholeskyTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,18 +20,16 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseCholesky;
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.LowerSPDDenseMatrix;
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.UpperSPDDenseMatrix;
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the dense Cholesky decomposition
  */
-public class DenseCholeskyTest extends TestCase {
+public class DenseCholeskyTest {
 
     private LowerSPDDenseMatrix L;
 
@@ -41,12 +39,8 @@ public class DenseCholeskyTest extends TestCase {
 
     private final int max = 50;
 
-    public DenseCholeskyTest(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
 
         L = new LowerSPDDenseMatrix(n);
@@ -64,13 +58,14 @@ public class DenseCholeskyTest extends TestCase {
         I = Matrices.identity(n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         L = null;
         U = null;
         I = null;
     }
 
+    @Test
     public void testLowerDenseCholesky() {
         int n = L.numRows();
 
@@ -89,6 +84,7 @@ public class DenseCholeskyTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testUpperDenseCholesky() {
         int n = U.numRows();
 
@@ -106,6 +102,7 @@ public class DenseCholeskyTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testLowerDenseCholeskyrcond() {
         int n = L.numRows();
 
@@ -115,6 +112,7 @@ public class DenseCholeskyTest extends TestCase {
         c.rcond(L);
     }
 
+    @Test
     public void testUpperDenseCholeskyrcond() {
         int n = U.numRows();
 

--- a/src/test/java/no/uib/cipr/matrix/DenseLUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/DenseLUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,12 +20,16 @@
 
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the dense LU decomposition
  */
-public class DenseLUTest extends TestCase {
+public class DenseLUTest {
 
     /**
      * Matrix to decompose
@@ -36,12 +40,8 @@ public class DenseLUTest extends TestCase {
 
     private final int max = 100;
 
-    public DenseLUTest(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
         A = new DenseMatrix(n, n);
         Utilities.populate(A);
@@ -52,12 +52,13 @@ public class DenseLUTest extends TestCase {
         I = Matrices.identity(n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         A = null;
         I = null;
     }
 
+    @Test
     public void testDenseLU() {
         int n = A.numRows();
         DenseLU lu = new DenseLU(n, n);
@@ -74,6 +75,7 @@ public class DenseLUTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testDenseLUtranspose() {
         int n = A.numRows();
         DenseLU lu = new DenseLU(n, n);
@@ -90,6 +92,7 @@ public class DenseLUTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testDenseLUrcond() {
         int n = A.numRows();
         DenseLU lu = new DenseLU(n, n);
@@ -99,6 +102,7 @@ public class DenseLUTest extends TestCase {
         lu.rcond(A, Matrix.Norm.Infinity);
     }
 
+    @Test
     public void testDensePLU() {
         Matrix m = new DenseMatrix(new double[][]{{2, -1, -2}, {-4, 6, 3},
                 {-4, -2, 8}});
@@ -111,7 +115,7 @@ public class DenseLUTest extends TestCase {
         Matrix lu = l.mult(u, new DenseMatrix(3, 3));
         Matrix x = p.mult(lu, new DenseMatrix(3, 3));
 
-        MatrixTestAbstract.assertEquals(m, x);
+        MatrixTestAbstract.assertMatrixEquals(m, x);
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/DenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/DenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,14 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test of a dense matrix
  */
 public class DenseMatrixTest extends MatrixTestAbstract {
-
-    public DenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {
@@ -39,30 +37,35 @@ public class DenseMatrixTest extends MatrixTestAbstract {
         Ad = Utilities.populate(A);
     }
 
+    @Test
     @Override
     public void testMatrixSolve() {
         if (A.isSquare())
             super.testMatrixSolve();
     }
 
+    @Test
     @Override
     public void testTransMatrixSolve() {
         if (A.isSquare())
             super.testTransMatrixSolve();
     }
 
+    @Test
     @Override
     public void testTransVectorSolve() {
         if (A.isSquare())
             super.testTransVectorSolve();
     }
 
+    @Test
     @Override
     public void testVectorSolve() {
         if (A.isSquare())
             super.testVectorSolve();
     }
 
+    @Test
     public void testIssue13() {
         Vector bv = Matrices.random(100);
         Matrix am = Matrices.random(100, 50);
@@ -74,6 +77,7 @@ public class DenseMatrixTest extends MatrixTestAbstract {
         xv = am.solve(bv, xv);
     }
 
+    @Test
     public void testIssue32() {
 
         // The issue here is that we should not allow matrices with more than

--- a/src/test/java/no/uib/cipr/matrix/DenseVectorSubTest.java
+++ b/src/test/java/no/uib/cipr/matrix/DenseVectorSubTest.java
@@ -7,10 +7,6 @@ import java.util.Random;
  */
 public class DenseVectorSubTest extends VectorTestAbstract {
 
-    public DenseVectorSubTest(String arg0) {
-        super(arg0);
-    }
-
     @Override
     protected void createPrimary() throws Exception {
         int n = Utilities.getInt(1, max);

--- a/src/test/java/no/uib/cipr/matrix/DenseVectorTest.java
+++ b/src/test/java/no/uib/cipr/matrix/DenseVectorTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseVector;
-
 /**
  * Test of DenseVector
  */
 public class DenseVectorTest extends VectorTestAbstract {
-
-    public DenseVectorTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/KhatriRaoTest.java
+++ b/src/test/java/no/uib/cipr/matrix/KhatriRaoTest.java
@@ -1,17 +1,18 @@
 /*
  * Copyright (C) 2015 Rogério Pontes
- * 
+ *
  */
 
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Test of the Khatri Rao Multiplication.
  */
-public class KhatriRaoTest extends TestCase {
+public class KhatriRaoTest {
 
+    @Test
     public void testEqualSizeKhatriRao() {
         Matrix A = new DenseMatrix(new double[][]{{1, 2, 3}, {4, 5, 6},
                 {7, 8, 9}});
@@ -23,10 +24,11 @@ public class KhatriRaoTest extends TestCase {
         KR mult = new KR(A, B);
         Matrix C = new DenseMatrix(A.numRows() * B.numRows(), A.numColumns());
         C = mult.multiply(C);
-        MatrixTestAbstract.assertEquals(C, res);
+        MatrixTestAbstract.assertMatrixEquals(C, res);
 
     }
 
+    @Test
     public void testEqualColumnKhatriRao() {
         Matrix A = new DenseMatrix(new double[][]{{1, 2}, {4, 2}, {7, 8}});
         Matrix B = new DenseMatrix(new double[][]{{1, 4}, {8, 5}, {5, 4},
@@ -37,10 +39,11 @@ public class KhatriRaoTest extends TestCase {
         KR mult = new KR(A, B);
         Matrix C = new DenseMatrix(A.numRows() * B.numRows(), A.numColumns());
         C = mult.multiply(C);
-        MatrixTestAbstract.assertEquals(C, res);
+        MatrixTestAbstract.assertMatrixEquals(C, res);
 
     }
 
+    @Test
     public void testEqualRowKhatriRao() {
         Matrix A = new DenseMatrix(new double[][]{{1, 2, 4, 5, 6},
                 {2, 8, 9, 2, 3}});
@@ -53,7 +56,7 @@ public class KhatriRaoTest extends TestCase {
         KR mult = new KR(A, B);
         Matrix C = new DenseMatrix(A.numRows() * B.numRows(), A.numColumns());
         C = mult.multiply(C);
-        MatrixTestAbstract.assertEquals(C, res);
+        MatrixTestAbstract.assertMatrixEquals(C, res);
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/LQTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LQTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,65 +20,67 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.LQ;
-import no.uib.cipr.matrix.Matrix;
+import org.junit.Test;
 
 /**
  * LQ test
  */
 public class LQTest extends OrthogonalTestAbstract {
 
-    public LQTest(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     public void testStaticFactorize() {
-        assertEquals(A, LQ.factorize(A));
+        assertLQEquals(A, LQ.factorize(A));
     }
 
+    @Test
     public void testRepeatStaticFactorize() {
-        assertEquals(A, LQ.factorize(A));
-        assertEquals(A, LQ.factorize(A));
+        assertLQEquals(A, LQ.factorize(A));
+        assertLQEquals(A, LQ.factorize(A));
     }
 
+    @Test
     public void testFactor() {
         LQ lq = new LQ(A.numRows(), A.numColumns());
-        assertEquals(A, lq.factor(new DenseMatrix(A)));
+        assertLQEquals(A, lq.factor(new DenseMatrix(A)));
     }
 
+    @Test
     public void testRepeatFactor() {
         LQ lq = new LQ(A.numRows(), A.numColumns());
         lq.factor(new DenseMatrix(A));
-        assertEquals(A, lq);
+        assertLQEquals(A, lq);
         lq.factor(new DenseMatrix(A));
-        assertEquals(A, lq);
+        assertLQEquals(A, lq);
     }
 
+    @Test
     public void testStaticFactorizeNonSquare() {
-        assertEquals(Ac, LQ.factorize(Ac));
+        assertLQEquals(Ac, LQ.factorize(Ac));
     }
 
+    @Test
     public void testRepeatStaticFactorizeNonSquare() {
-        assertEquals(Ac, LQ.factorize(Ac));
-        assertEquals(Ac, LQ.factorize(Ac));
+        assertLQEquals(Ac, LQ.factorize(Ac));
+        assertLQEquals(Ac, LQ.factorize(Ac));
     }
 
+    @Test
     public void testFactorNonSquare() {
         LQ lq = new LQ(Ac.numRows(), Ac.numColumns());
-        assertEquals(Ac, lq.factor(new DenseMatrix(Ac)));
+        assertLQEquals(Ac, lq.factor(new DenseMatrix(Ac)));
     }
 
+    @Test
     public void testRepeatFactorNonSquare() {
         LQ lq = new LQ(Ac.numRows(), Ac.numColumns());
         lq.factor(new DenseMatrix(Ac));
-        assertEquals(Ac, lq);
+        assertLQEquals(Ac, lq);
         lq.factor(new DenseMatrix(Ac));
-        assertEquals(Ac, lq);
+        assertLQEquals(Ac, lq);
     }
 
-    private void assertEquals(Matrix A, LQ lq) {
-        assertEquals(A, lq.getL().mult(lq.getQ(), A.copy().zero()));
+    private void assertLQEquals(Matrix A, LQ lq) {
+        assertMatrixEquals(A, lq.getL().mult(lq.getQ(), A.copy().zero()));
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/LowerSPDBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerSPDBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSPDBandMatrix;
-
 /**
  * Test of LowerSPDBandMatrix
  */
 public class LowerSPDBandMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public LowerSPDBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerSPDDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerSPDDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSPDDenseMatrix;
-
 /**
  * Test of LowerSPDDenseMatrix
  */
 public class LowerSPDDenseMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public LowerSPDDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerSPDPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerSPDPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSPDPackMatrix;
-
 /**
  * Test of LowerSPDPackMatrix
  */
 public class LowerSPDPackMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public LowerSPDPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerSymmBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerSymmBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSymmBandMatrix;
-
 /**
  * Test of LowerSymmBandMatrix
  */
 public class LowerSymmBandMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public LowerSymmBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerSymmDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerSymmDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSymmDenseMatrix;
-
 /**
  * Test of LowerSymmDenseMatrix
  */
 public class LowerSymmDenseMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public LowerSymmDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerSymmPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerSymmPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSymmPackMatrix;
-
 /**
  * Test of LowerSymmPackMatrix
  */
 public class LowerSymmPackMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public LowerSymmPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerTriangBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerTriangBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerTriangBandMatrix;
-
 /**
  * Test of LowerTriangBandMatrix
  */
 public class LowerTriangBandMatrixTest extends TriangMatrixTestAbstract {
-
-    public LowerTriangBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerTriangDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerTriangDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerTriangDenseMatrix;
-
 /**
  * Test of LowerTriangDenseMatrix
  */
 public class LowerTriangDenseMatrixTest extends TriangMatrixTestAbstract {
-
-    public LowerTriangDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/LowerTriangPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/LowerTriangPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerTriangPackMatrix;
-
 /**
  * Test of LowerTriangPackMatrix
  */
 public class LowerTriangPackMatrixTest extends TriangMatrixTestAbstract {
-
-    public LowerTriangPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/MatrixTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/MatrixTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,12 +20,16 @@
 
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests a matrix
  */
-public abstract class MatrixTestAbstract extends TestCase {
+public abstract class MatrixTestAbstract {
 
     /**
      * Matrix to test
@@ -82,23 +86,16 @@ public abstract class MatrixTestAbstract extends TestCase {
      */
     protected int max = 100;
 
-    /**
-     * Constructor for MatrixTestAbstract
-     */
-    public MatrixTestAbstract(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         createPrimary();
         createAuxillerary();
     }
 
     protected abstract void createPrimary() throws Exception;
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         A = B = Bdense = null;
         Ad = Bd = null;
         xC = xDenseC = xDenseR = xR = yC = yDenseC = yDenseR = yR = null;
@@ -132,6 +129,7 @@ public abstract class MatrixTestAbstract extends TestCase {
         ydR = Matrices.getArray(yR);
     }
 
+    @Test
     public void testMatrixRank2Dense() {
         if (A.isSquare()) {
             int n = Utilities.getInt(1, max);
@@ -143,12 +141,13 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.rank2(alpha, B, C);
             rank2(Ad, alpha, Bd, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Bd, B);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Bd, B);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixRank2() {
         if (A.isSquare()) {
             int n = Utilities.getInt(1, max);
@@ -161,12 +160,13 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.rank2(alpha, B, C);
             rank2(Ad, alpha, Bd, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Bd, B);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Bd, B);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixTransRank2Dense() {
         if (A.isSquare()) {
             int n = Utilities.getInt(1, max);
@@ -178,12 +178,13 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.transRank2(alpha, B, C);
             transRank2(Ad, alpha, Bd, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Bd, B);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Bd, B);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixTransRank2() {
         if (A.isSquare()) {
             int n = Utilities.getInt(1, max);
@@ -196,12 +197,13 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.transRank2(alpha, B, C);
             transRank2(Ad, alpha, Bd, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Bd, B);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Bd, B);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixRank1Dense() {
         if (A.isSquare()) {
             Matrix C = Matrices.random(A.numRows(), A.numColumns());
@@ -211,11 +213,12 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.rank1(alpha, C);
             rank1(Ad, alpha, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixRank1() {
         if (A.isSquare()) {
             Matrix C = Matrices.synchronizedMatrix(Matrices.random(A.numRows(),
@@ -226,11 +229,12 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.rank1(alpha, C);
             rank1(Ad, alpha, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixTransRank1Dense() {
         if (A.isSquare()) {
             Matrix C = Matrices.random(A.numRows(), A.numColumns());
@@ -240,11 +244,12 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.transRank1(alpha, C);
             transRank1(Ad, alpha, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixTransRank1() {
         if (A.isSquare()) {
             Matrix C = Matrices.synchronizedMatrix(Matrices.random(A.numRows(),
@@ -255,11 +260,12 @@ public abstract class MatrixTestAbstract extends TestCase {
             A = A.transRank1(alpha, C);
             transRank1(Ad, alpha, Cd);
 
-            assertEquals(Ad, A);
-            assertEquals(Cd, C);
+            assertMatrixEquals(Ad, A);
+            assertMatrixEquals(Cd, C);
         }
     }
 
+    @Test
     public void testMatrixMultDense() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(k, n), C = Matrices.random(m, n);
@@ -269,11 +275,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.mult(alpha, B, C);
         Cd = mult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixMult() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(k, n)), C = Matrices
@@ -284,11 +291,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.mult(alpha, B, C);
         Cd = mult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransAmultDense() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(k, n), C = Matrices.random(m, n);
@@ -298,11 +306,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transAmult(alpha, B, C);
         Cd = transAmult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransAmult() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(k, n)), C = Matrices
@@ -313,11 +322,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transAmult(alpha, B, C);
         Cd = transAmult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransABmultDense() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(n, k), C = Matrices.random(m, n);
@@ -327,11 +337,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transABmult(alpha, B, C);
         Cd = transABmult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransABmult() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(n, k)), C = Matrices
@@ -342,11 +353,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transABmult(alpha, B, C);
         Cd = transABmult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransBmultDense() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(n, k), C = Matrices.random(m, n);
@@ -356,11 +368,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transBmult(alpha, B, C);
         Cd = transBmult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransBmult() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(n, k)), C = Matrices
@@ -371,11 +384,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transBmult(alpha, B, C);
         Cd = transBmult(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixMultAddDense() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(k, n), C = Matrices.random(m, n);
@@ -385,11 +399,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.multAdd(alpha, B, C);
         Cd = multAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixMultAdd() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(k, n)), C = Matrices
@@ -400,11 +415,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.multAdd(alpha, B, C);
         Cd = multAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransAmultAddDense() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(k, n), C = Matrices.random(m, n);
@@ -414,11 +430,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transAmultAdd(alpha, B, C);
         Cd = transAmultAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransAmultAdd() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(k, n)), C = Matrices
@@ -429,11 +446,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transAmultAdd(alpha, B, C);
         Cd = transAmultAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransABmultAddDense() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(n, k), C = Matrices.random(m, n);
@@ -443,11 +461,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transABmultAdd(alpha, B, C);
         Cd = transABmultAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransABmultAdd() {
         int m = A.numColumns(), k = A.numRows(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(n, k)), C = Matrices
@@ -458,11 +477,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transABmultAdd(alpha, B, C);
         Cd = transABmultAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransBmultAddDense() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.random(n, k), C = Matrices.random(m, n);
@@ -472,11 +492,12 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transBmultAdd(alpha, B, C);
         Cd = transBmultAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
+    @Test
     public void testMatrixTransBmultAdd() {
         int m = A.numRows(), k = A.numColumns(), n = Utilities.getInt(1, max);
         Matrix B = Matrices.synchronizedMatrix(Matrices.random(n, k)), C = Matrices
@@ -487,9 +508,9 @@ public abstract class MatrixTestAbstract extends TestCase {
         C = A.transBmultAdd(alpha, B, C);
         Cd = transBmultAdd(Ad, alpha, Bd, Cd);
 
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
-        assertEquals(Cd, C);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
+        assertMatrixEquals(Cd, C);
     }
 
     protected double[][] rank2(double[][] Ad, double alpha, double[][] Bd,
@@ -510,33 +531,37 @@ public abstract class MatrixTestAbstract extends TestCase {
         return transAmultAdd(Cd, alpha, Cd, Ad);
     }
 
+    @Test
     public void testVectorRank2Dense() {
         if (A.isSquare()) {
             double alpha = Math.random();
-            assertEquals(rank2(alpha, xdR, ydR),
+            assertMatrixEquals(rank2(alpha, xdR, ydR),
                     A.rank2(alpha, xDenseR, yDenseR));
         }
     }
 
+    @Test
     public void testVectorRank2() {
         if (A.isSquare()) {
             double alpha = Math.random();
-            assertEquals(rank2(alpha, xdR, ydR), A.rank2(alpha, xR, yR));
+            assertMatrixEquals(rank2(alpha, xdR, ydR), A.rank2(alpha, xR, yR));
         }
     }
 
+    @Test
     public void testVectorRank1Dense() {
         if (A.isSquare()) {
             double alpha = Math.random();
-            assertEquals(rank1(alpha, xdR, ydR),
+            assertMatrixEquals(rank1(alpha, xdR, ydR),
                     A.rank1(alpha, xDenseR, yDenseR));
         }
     }
 
+    @Test
     public void testVectorRank1() {
         if (A.isSquare()) {
             double alpha = Math.random();
-            assertEquals(rank1(alpha, xdR, ydR), A.rank1(alpha, xR, yR));
+            assertMatrixEquals(rank1(alpha, xdR, ydR), A.rank1(alpha, xR, yR));
         }
     }
 
@@ -553,22 +578,24 @@ public abstract class MatrixTestAbstract extends TestCase {
         return Ad;
     }
 
+    @Test
     public void testVectorTransMultAddDense() {
         double alpha = Math.random();
-        assertEquals(transMultAdd(alpha, xdR, ydC),
+        assertVectorEquals(transMultAdd(alpha, xdR, ydC),
                 A.transMultAdd(alpha, xDenseR, yDenseC));
-        assertEquals(Ad, A);
-        assertEquals(xdR, xDenseR);
-        assertEquals(ydC, yDenseC);
+        assertMatrixEquals(Ad, A);
+        assertVectorEquals(xdR, xDenseR);
+        assertVectorEquals(ydC, yDenseC);
     }
 
+    @Test
     public void testVectorTransMultAdd() {
         double alpha = Math.random();
-        assertEquals(transMultAdd(alpha, xdR, ydC),
+        assertVectorEquals(transMultAdd(alpha, xdR, ydC),
                 A.transMultAdd(alpha, xR, yC));
-        assertEquals(Ad, A);
-        assertEquals(xdR, xR);
-        assertEquals(ydC, yC);
+        assertMatrixEquals(Ad, A);
+        assertVectorEquals(xdR, xR);
+        assertVectorEquals(ydC, yC);
     }
 
     protected double[] transMultAdd(double alpha, double[] xd, double[] yd) {
@@ -586,20 +613,23 @@ public abstract class MatrixTestAbstract extends TestCase {
         return yd;
     }
 
+    @Test
     public void testVectorMultDense() {
         double alpha = Math.random();
-        assertEquals(mult(alpha, xdC, ydR), A.mult(alpha, xDenseC, yDenseR));
-        assertEquals(Ad, A);
-        assertEquals(xdC, xDenseC);
-        assertEquals(ydR, yDenseR);
+        assertVectorEquals(mult(alpha, xdC, ydR),
+                A.mult(alpha, xDenseC, yDenseR));
+        assertMatrixEquals(Ad, A);
+        assertVectorEquals(xdC, xDenseC);
+        assertVectorEquals(ydR, yDenseR);
     }
 
+    @Test
     public void testVectorMult() {
         double alpha = Math.random();
-        assertEquals(mult(alpha, xdC, ydR), A.mult(alpha, xC, yR));
-        assertEquals(Ad, A);
-        assertEquals(xdC, xC);
-        assertEquals(ydR, yR);
+        assertVectorEquals(mult(alpha, xdC, ydR), A.mult(alpha, xC, yR));
+        assertMatrixEquals(Ad, A);
+        assertVectorEquals(xdC, xC);
+        assertVectorEquals(ydR, yR);
     }
 
     protected double[] mult(double alpha, double[] xd, double[] yd) {
@@ -612,21 +642,24 @@ public abstract class MatrixTestAbstract extends TestCase {
         return yd;
     }
 
+    @Test
     public void testVectorMultAddDense() {
         double alpha = Math.random();
-        assertEquals(multAdd(Ad, alpha, xdC, ydR),
+        assertVectorEquals(multAdd(Ad, alpha, xdC, ydR),
                 A.multAdd(alpha, xDenseC, yDenseR));
-        assertEquals(Ad, A);
-        assertEquals(xdC, xDenseC);
-        assertEquals(ydR, yDenseR);
+        assertMatrixEquals(Ad, A);
+        assertVectorEquals(xdC, xDenseC);
+        assertVectorEquals(ydR, yDenseR);
     }
 
+    @Test
     public void testVectorMultAdd() {
         double alpha = Math.random();
-        assertEquals(multAdd(Ad, alpha, xdC, ydR), A.multAdd(alpha, xC, yR));
-        assertEquals(Ad, A);
-        assertEquals(xdC, xC);
-        assertEquals(ydR, yR);
+        assertVectorEquals(multAdd(Ad, alpha, xdC, ydR),
+                A.multAdd(alpha, xC, yR));
+        assertMatrixEquals(Ad, A);
+        assertVectorEquals(xdC, xC);
+        assertVectorEquals(ydR, yR);
     }
 
     protected double[] multAdd(double[][] Ad, double alpha, double[] xd,
@@ -773,91 +806,100 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Tests <code>A = A + alpha*B</code>
      */
+    @Test
     public void testRandomMatrixAdd() {
         double alpha = Math.random();
         A = A.add(alpha, B);
         add(Ad, alpha, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Tests <code>A = A + B</code>
      */
+    @Test
     public void testMatrixAdd() {
         A = A.add(B);
         add(Ad, 1, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Tests <code>A = A + 1*B</code>
      */
+    @Test
     public void testOneMatrixAdd() {
         A = A.add(1, B);
         add(Ad, 1, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Tests <code>A = A + 0*B</code>
      */
+    @Test
     public void testZeroMatrixAdd() {
         A = A.add(0, B);
         add(Ad, 0, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Tests <code>A = alpha*B</code>
      */
+    @Test
     public void testRandomMatrixSet() {
         double alpha = Math.random();
         A = A.set(alpha, B);
         set(Ad, alpha, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Tests <code>A = B</code>
      */
+    @Test
     public void testMatrixSet() {
         A = A.set(B);
         set(Ad, 1, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Tests <code>A = 1*B</code>
      */
+    @Test
     public void testOneMatrixSet() {
         A = A.set(1, B);
         set(Ad, 1, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Tests <code>A = 0*B</code>
      */
+    @Test
     public void testZeroMatrixSet() {
         A = A.set(0, B);
         set(Ad, 0, Bd);
-        assertEquals(Ad, A);
-        assertEquals(Bd, B);
+        assertMatrixEquals(Ad, A);
+        assertMatrixEquals(Bd, B);
     }
 
     /**
      * Checks transpose
      */
+    @Test
     public void testTranspose() {
         Matrix At = Matrices.random(A.numColumns(), A.numRows());
-        assertEquals(transpose(), A.transpose(At));
+        assertMatrixEquals(transpose(), A.transpose(At));
     }
 
     protected void set(double[][] A, double alpha, double[][] B) {
@@ -886,6 +928,7 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Test of direct matrix solver
      */
+    @Test
     public void testMatrixSolve() {
         while (true) {
             try {
@@ -895,7 +938,7 @@ public abstract class MatrixTestAbstract extends TestCase {
 
                 Matrix Y = A.multAdd(X, X.copy().set(-1, B));
                 assertEquals(0, Y.norm(Matrix.Norm.Frobenius), tol);
-                assertEquals(Ad, A);
+                assertMatrixEquals(Ad, A);
                 return;
             } catch (MatrixSingularException e) {
                 Utilities.addDiagonal(A, Ad, 1);
@@ -908,6 +951,7 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Test of direct transpose matrix solver
      */
+    @Test
     public void testTransMatrixSolve() {
         while (true) {
             try {
@@ -917,7 +961,7 @@ public abstract class MatrixTestAbstract extends TestCase {
 
                 Matrix Y = A.transAmultAdd(X, X.copy().set(-1, B));
                 assertEquals(0, Y.norm(Matrix.Norm.Frobenius), tol);
-                assertEquals(Ad, A);
+                assertMatrixEquals(Ad, A);
                 return;
             } catch (MatrixSingularException e) {
                 Utilities.addDiagonal(A, Ad, 1);
@@ -930,6 +974,7 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Test of direct vector solver
      */
+    @Test
     public void testVectorSolve() {
         while (true) {
             try {
@@ -939,7 +984,7 @@ public abstract class MatrixTestAbstract extends TestCase {
 
                 Vector y = A.multAdd(-1, x, x.copy().set(b));
                 assertEquals(0, y.norm(Vector.Norm.Two), tol);
-                assertEquals(Ad, A);
+                assertMatrixEquals(Ad, A);
                 return;
             } catch (MatrixSingularException e) {
                 Utilities.addDiagonal(A, Ad, 1);
@@ -952,6 +997,7 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Test of direct transpose vector solver
      */
+    @Test
     public void testTransVectorSolve() {
         while (true) {
             try {
@@ -961,7 +1007,7 @@ public abstract class MatrixTestAbstract extends TestCase {
 
                 Vector y = A.transMultAdd(-1, x, x.copy().set(b));
                 assertEquals(0, y.norm(Vector.Norm.Two), tol);
-                assertEquals(Ad, A);
+                assertMatrixEquals(Ad, A);
                 return;
             } catch (MatrixSingularException e) {
                 Utilities.addDiagonal(A, Ad, 1);
@@ -974,47 +1020,52 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Test additions using iterators
      */
+    @Test
     public void testAdd() {
         double alpha = Math.random();
         for (MatrixEntry e : A) {
             A.add(e.row(), e.column(), alpha);
             A.add(e.row(), e.column(), -alpha);
         }
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
     /**
      * Checks that copy is deep, not reference
      */
+    @Test
     public void testCopy() {
         Matrix Ac = A.copy();
         A = A.zero();
-        assertEquals(Ad, Ac);
+        assertMatrixEquals(Ad, Ac);
     }
 
     /**
      * Test iterator get
      */
+    @Test
     public void testIterator() {
         double[][] Ac = new double[A.numRows()][A.numColumns()];
         for (MatrixEntry e : A)
             Ac[e.row()][e.column()] = e.get();
-        assertEquals(Ad, Ac);
+        assertMatrixEquals(Ad, Ac);
     }
 
     /**
      * Test iterator set
      */
+    @Test
     public void testIteratorSet() {
         double alpha = Math.random();
         for (MatrixEntry e : A)
             e.set(e.get() * alpha);
-        assertEquals(scale(alpha), A);
+        assertMatrixEquals(scale(alpha), A);
     }
 
     /**
      * Test iterator read and write
      */
+    @Test
     public void testIteratorSetGet() {
         double alpha = Math.random();
         double[][] Ac = new double[A.numRows()][A.numColumns()];
@@ -1023,15 +1074,16 @@ public abstract class MatrixTestAbstract extends TestCase {
             e.set(alpha * e.get());
             e.set(e.get() / alpha);
         }
-        assertEquals(Ad, Ac);
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, Ac);
+        assertMatrixEquals(Ad, A);
     }
 
     /**
      * Checks zero()
      */
+    @Test
     public void testZero() {
-        assertEquals(zero(), A.zero());
+        assertMatrixEquals(zero(), A.zero());
     }
 
     protected double[][] zero() {
@@ -1044,6 +1096,7 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Cardinality computation
      */
+    @Test
     public void testCardinality() {
         assertEquals(Matrices.cardinality(A), cardinality());
     }
@@ -1060,37 +1113,41 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Checks in-place transpose for square matrices
      */
+    @Test
     public void testTransposeInplace() {
         if (A.isSquare())
-            assertEquals(transpose(), A.copy().transpose());
+            assertMatrixEquals(transpose(), A.copy().transpose());
     }
 
     /**
      * Scaling with an arbitrary scalar
      */
+    @Test
     public void testScale() {
         double alpha = Math.random();
         A = A.scale(alpha);
         scale(alpha);
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
     /**
      * Scaling by zero
      */
+    @Test
     public void testZeroScale() {
         A = A.scale(0);
         scale(0);
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
     /**
      * Scaling by one
      */
+    @Test
     public void testOneScale() {
         A = A.scale(1);
         scale(1);
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
     protected double[][] scale(double alpha) {
@@ -1103,25 +1160,28 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Checks the 1 norm
      */
+    @Test
     public void testOneNorm() {
         assertEquals(norm1(Ad), A.norm(Matrix.Norm.One), tol);
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
     /**
      * Checks the Frobenius norm
      */
+    @Test
     public void testFrobeniusNorm() {
         assertEquals(normF(Ad), A.norm(Matrix.Norm.Frobenius), tol);
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
     /**
      * Checks the infinity norm
      */
+    @Test
     public void testInfinityNorm() {
         assertEquals(normInf(Ad), A.norm(Matrix.Norm.Infinity), tol);
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
     protected double norm1(double[][] A) {
@@ -1161,7 +1221,7 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Checks for equality between the matrix and the array
      */
-    protected void assertEquals(double[][] Ad, Matrix A) {
+    protected void assertMatrixEquals(double[][] Ad, Matrix A) {
         assertTrue(A != null);
         assertTrue(Ad != null);
         assertTrue(A.numRows() == Ad.length);
@@ -1175,7 +1235,7 @@ public abstract class MatrixTestAbstract extends TestCase {
     /**
      * Checks for equality between two arrays
      */
-    protected void assertEquals(double[][] Ad, double[][] Ac) {
+    protected void assertMatrixEquals(double[][] Ad, double[][] Ac) {
         assertTrue(Ac.length == Ad.length);
         for (int i = 0; i < A.numRows(); ++i) {
             assertTrue(Ac[i].length == Ad[i].length);
@@ -1184,18 +1244,18 @@ public abstract class MatrixTestAbstract extends TestCase {
         }
     }
 
-    protected void assertEquals(double[] xd, Vector x) {
+    protected void assertVectorEquals(double[] xd, Vector x) {
         assertEquals(xd.length, x.size());
         for (int i = 0; i < xd.length; ++i)
             assertEquals(xd[i], x.get(i), tol);
     }
 
-    protected void assertEquals(double[] xd, double[] yd) {
+    protected void assertVectorEquals(double[] xd, double[] yd) {
         for (int i = 0; i < xd.length; ++i)
             assertEquals(xd[i], yd[i], tol);
     }
 
-    public static void assertEquals(Matrix expected, Matrix test) {
+    public static void assertMatrixEquals(Matrix expected, Matrix test) {
         assertEquals(expected.numRows(), test.numRows());
         assertEquals(expected.numColumns(), test.numColumns());
         for (int i = 0; i < test.numRows(); i++) {
@@ -1205,7 +1265,7 @@ public abstract class MatrixTestAbstract extends TestCase {
         }
     }
 
-    public static void assertEquals(Vector expected, Vector test) {
+    public static void assertVectorEquals(Vector expected, Vector test) {
         assertEquals(expected.size(), test.size());
         for (int i = 0; i < test.size(); i++) {
             assertEquals(expected.get(i), test.get(i), 0.0001);

--- a/src/test/java/no/uib/cipr/matrix/OrthogonalTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/OrthogonalTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,14 +20,15 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.Matrix;
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Orthogonal matrix decomposition tests
  */
-public abstract class OrthogonalTestAbstract extends TestCase {
+public abstract class OrthogonalTestAbstract {
 
     /**
      * Initial work-matrix, and non-square matrices
@@ -39,12 +40,8 @@ public abstract class OrthogonalTestAbstract extends TestCase {
      */
     private final int max = 100;
 
-    public OrthogonalTestAbstract(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
         int m = Utilities.getInt(1, n);
         A = Matrices.random(n, n);
@@ -52,12 +49,12 @@ public abstract class OrthogonalTestAbstract extends TestCase {
         Ac = Matrices.random(m, n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         A = Ar = Ac = null;
     }
 
-    protected void assertEquals(Matrix A, Matrix B) {
+    protected void assertMatrixEquals(Matrix A, Matrix B) {
         for (int i = 0; i < A.numRows(); ++i)
             for (int j = 0; j < A.numColumns(); ++j)
                 assertEquals(A.get(i, j), B.get(i, j), 1e-12);

--- a/src/test/java/no/uib/cipr/matrix/PackCholeskyTest.java
+++ b/src/test/java/no/uib/cipr/matrix/PackCholeskyTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,18 +20,16 @@
 
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.LowerSPDPackMatrix;
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.PackCholesky;
-import no.uib.cipr.matrix.UpperSPDPackMatrix;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the packed Cholesky decomposition
  */
-public class PackCholeskyTest extends TestCase {
+public class PackCholeskyTest {
 
     private LowerSPDPackMatrix L;
 
@@ -41,12 +39,8 @@ public class PackCholeskyTest extends TestCase {
 
     private final int max = 50;
 
-    public PackCholeskyTest(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
 
         L = new LowerSPDPackMatrix(n);
@@ -64,13 +58,14 @@ public class PackCholeskyTest extends TestCase {
         I = Matrices.identity(n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         L = null;
         U = null;
         I = null;
     }
 
+    @Test
     public void testLowerPackCholesky() {
         int n = L.numRows();
 
@@ -88,6 +83,7 @@ public class PackCholeskyTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testUpperPackCholesky() {
         int n = U.numRows();
 
@@ -105,6 +101,7 @@ public class PackCholeskyTest extends TestCase {
                     assertEquals(J.get(i, j), 1, 1e-10);
     }
 
+    @Test
     public void testLowerPackCholeskyrcond() {
         int n = L.numRows();
 
@@ -114,6 +111,7 @@ public class PackCholeskyTest extends TestCase {
         c.rcond(L);
     }
 
+    @Test
     public void testUpperPackCholeskyrcond() {
         int n = U.numRows();
 

--- a/src/test/java/no/uib/cipr/matrix/PermutationMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/PermutationMatrixTest.java
@@ -1,12 +1,12 @@
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
 import no.uib.cipr.matrix.sparse.CompRowMatrix;
+import org.junit.Test;
 
 /**
  * @author Sam Halliday
  */
-public class PermutationMatrixTest extends TestCase {
+public class PermutationMatrixTest {
 
     Matrix m = new DenseMatrix(new double[][]{{2, -1, -2}, {-4, 6, 3},
             {-4, -2, 8}});
@@ -16,15 +16,17 @@ public class PermutationMatrixTest extends TestCase {
             {-4, 6, 3}});
     int[] piv = new int[]{2, 3, 3};
 
+    @Test
     public void testMultiply() {
         Matrix p = PermutationMatrix.fromPartialPivots(piv);
         Matrix c = p
                 .mult(m,
                         new CompRowMatrix(new DenseMatrix(m.numRows(), m
                                 .numColumns())));
-        MatrixTestAbstract.assertEquals(e, c);
+        MatrixTestAbstract.assertMatrixEquals(e, c);
     }
 
+    @Test
     public void testMultiplyTrans() {
         Matrix p = PermutationMatrix.fromPartialPivots(piv);
         Matrix c = p
@@ -32,34 +34,38 @@ public class PermutationMatrixTest extends TestCase {
                         m,
                         new CompRowMatrix(new DenseMatrix(m.numRows(), m
                                 .numColumns())));
-        MatrixTestAbstract.assertEquals(eI, c);
+        MatrixTestAbstract.assertMatrixEquals(eI, c);
     }
 
+    @Test
     public void testMultiplyDense() {
         Matrix p = PermutationMatrix.fromPartialPivots(piv);
         Matrix c = p.mult(m, new DenseMatrix(m.numRows(), m.numColumns()));
-        MatrixTestAbstract.assertEquals(e, c);
+        MatrixTestAbstract.assertMatrixEquals(e, c);
     }
 
+    @Test
     public void testMultiplyTransDense() {
         Matrix p = PermutationMatrix.fromPartialPivots(piv);
         Matrix c = p
                 .transAmult(m, new DenseMatrix(m.numRows(), m.numColumns()));
-        MatrixTestAbstract.assertEquals(eI, c);
+        MatrixTestAbstract.assertMatrixEquals(eI, c);
     }
 
+    @Test
     public void testMultiplyCompRow() {
         Matrix p = PermutationMatrix.fromPartialPivots(piv);
         Matrix c = p.mult(new CompRowMatrix(m), new CompRowMatrix(
                 new DenseMatrix(m.numRows(), m.numColumns())));
-        MatrixTestAbstract.assertEquals(e, c);
+        MatrixTestAbstract.assertMatrixEquals(e, c);
     }
 
+    @Test
     public void testMultiplyTransCompRow() {
         Matrix p = PermutationMatrix.fromPartialPivots(piv);
         Matrix c = p.transAmult(new CompRowMatrix(m), new CompRowMatrix(
                 new DenseMatrix(m.numRows(), m.numColumns())));
-        MatrixTestAbstract.assertEquals(eI, c);
+        MatrixTestAbstract.assertMatrixEquals(eI, c);
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/QLTest.java
+++ b/src/test/java/no/uib/cipr/matrix/QLTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,65 +20,67 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.QL;
+import org.junit.Test;
 
 /**
  * QL test
  */
 public class QLTest extends OrthogonalTestAbstract {
 
-    public QLTest(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     public void testStaticFactorize() {
-        assertEquals(A, QL.factorize(A));
+        assertEqualsQL(A, QL.factorize(A));
     }
 
+    @Test
     public void testRepeatStaticFactorize() {
-        assertEquals(A, QL.factorize(A));
-        assertEquals(A, QL.factorize(A));
+        assertEqualsQL(A, QL.factorize(A));
+        assertEqualsQL(A, QL.factorize(A));
     }
 
+    @Test
     public void testFactor() {
         QL ql = new QL(A.numRows(), A.numColumns());
-        assertEquals(A, ql.factor(new DenseMatrix(A)));
+        assertEqualsQL(A, ql.factor(new DenseMatrix(A)));
     }
 
+    @Test
     public void testRepeatFactor() {
         QL ql = new QL(A.numRows(), A.numColumns());
         ql.factor(new DenseMatrix(A));
-        assertEquals(A, ql);
+        assertEqualsQL(A, ql);
         ql.factor(new DenseMatrix(A));
-        assertEquals(A, ql);
+        assertEqualsQL(A, ql);
     }
 
+    @Test
     public void testStaticFactorizeNonSquare() {
-        assertEquals(Ar, QL.factorize(Ar));
+        assertEqualsQL(Ar, QL.factorize(Ar));
     }
 
+    @Test
     public void testRepeatStaticFactorizeNonSquare() {
-        assertEquals(Ar, QL.factorize(Ar));
-        assertEquals(Ar, QL.factorize(Ar));
+        assertEqualsQL(Ar, QL.factorize(Ar));
+        assertEqualsQL(Ar, QL.factorize(Ar));
     }
 
+    @Test
     public void testFactorNonSquare() {
         QL ql = new QL(Ar.numRows(), Ar.numColumns());
-        assertEquals(Ar, ql.factor(new DenseMatrix(Ar)));
+        assertEqualsQL(Ar, ql.factor(new DenseMatrix(Ar)));
     }
 
+    @Test
     public void testRepeatFactorNonSquare() {
         QL ql = new QL(Ar.numRows(), Ar.numColumns());
         ql.factor(new DenseMatrix(Ar));
-        assertEquals(Ar, ql);
+        assertEqualsQL(Ar, ql);
         ql.factor(new DenseMatrix(Ar));
-        assertEquals(Ar, ql);
+        assertEqualsQL(Ar, ql);
     }
 
-    private void assertEquals(Matrix A, QL ql) {
-        assertEquals(A, ql.getQ().mult(ql.getL(), A.copy().zero()));
+    private void assertEqualsQL(Matrix A, QL ql) {
+        assertMatrixEquals(A, ql.getQ().mult(ql.getL(), A.copy().zero()));
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/QRPTest.java
+++ b/src/test/java/no/uib/cipr/matrix/QRPTest.java
@@ -19,22 +19,26 @@
  */
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * QRP test
  */
-public class QRPTest extends TestCase {
+public class QRPTest {
 
+    @Test
     public void testIdentity() {
         Matrix A = Matrices.identity(5);
 
         QRP qrp = QRP.factorize(A);
 
-        assertEquals(A,
+        assertMatrixEquals(A,
                 mult(qrp.getQ(), qrp.getPVector(), qrp.getR(), A.copy().zero()));
     }
 
+    @Test
     public void testRectangularIdentity1() {
         Matrix A = new DenseMatrix(5, 6);
         for (MatrixEntry i : A) {
@@ -44,10 +48,11 @@ public class QRPTest extends TestCase {
 
         QRP qrp = QRP.factorize(A);
 
-        assertEquals(A,
+        assertMatrixEquals(A,
                 mult(qrp.getQ(), qrp.getPVector(), qrp.getR(), A.copy().zero()));
     }
 
+    @Test
     public void testRectangularIdentity2() {
         Matrix A = new DenseMatrix(6, 5);
         for (MatrixEntry i : A) {
@@ -57,10 +62,11 @@ public class QRPTest extends TestCase {
 
         QRP qrp = QRP.factorize(A);
 
-        assertEquals(A,
+        assertMatrixEquals(A,
                 mult(qrp.getQ(), qrp.getPVector(), qrp.getR(), A.copy().zero()));
     }
 
+    @Test
     public void testOrthogonality() {
         Matrix A = Matrices.random(6, 4);
 
@@ -68,10 +74,11 @@ public class QRPTest extends TestCase {
 
         Matrix QP = qrp.getQ();
 
-        assertEquals(Matrices.identity(QP.numRows()),
+        assertMatrixEquals(Matrices.identity(QP.numRows()),
                 QP.transAmult(QP, QP.copy().zero()));
     }
 
+    @Test
     public void testOrthogonality2() {
         Matrix A = Matrices.random(4, 6);
 
@@ -79,10 +86,11 @@ public class QRPTest extends TestCase {
 
         Matrix QP = qrp.getQ();
 
-        assertEquals(Matrices.identity(QP.numRows()),
+        assertMatrixEquals(Matrices.identity(QP.numRows()),
                 QP.transAmult(QP, QP.copy().zero()));
     }
 
+    @Test
     public void testRandSquare() {
         Matrix A = Matrices.random(5, 5);
 
@@ -91,27 +99,30 @@ public class QRPTest extends TestCase {
         Matrix R = qrp.getR();
         int P[] = qrp.getPVector();
 
-        assertEquals(A, mult(Q, P, R, A.copy().zero()));
+        assertMatrixEquals(A, mult(Q, P, R, A.copy().zero()));
     }
 
+    @Test
     public void testRandRectangular1() {
         Matrix A = Matrices.random(4, 6);
 
         QRP qrp = QRP.factorize(A);
 
-        assertEquals(A,
+        assertMatrixEquals(A,
                 mult(qrp.getQ(), qrp.getPVector(), qrp.getR(), A.copy().zero()));
     }
 
+    @Test
     public void testRandRectangular2() {
         Matrix A = Matrices.random(6, 4);
 
         QRP qrp = QRP.factorize(A);
 
-        assertEquals(A,
+        assertMatrixEquals(A,
                 mult(qrp.getQ(), qrp.getPVector(), qrp.getR(), A.copy().zero()));
     }
 
+    @Test
     public void testPivotingMatrix() {
         Matrix A = Matrices.random(6, 4);
 
@@ -126,9 +137,10 @@ public class QRPTest extends TestCase {
         Q.mult(R, C);
         C.transBmult(P, D);
 
-        assertEquals(A, D);
+        assertMatrixEquals(A, D);
     }
 
+    @Test
     public void testRank1() {
         Matrix rand = Matrices.random(6, 4);
 
@@ -140,6 +152,7 @@ public class QRPTest extends TestCase {
         assertEquals(Math.min(rand.numRows(), rand.numColumns()), qrp.getRank());
     }
 
+    @Test
     public void testRank2() {
         Matrix rand = Matrices.random(4, 6);
 
@@ -181,7 +194,7 @@ public class QRPTest extends TestCase {
     /**
      * Assert that the given matrices are identical
      */
-    protected void assertEquals(Matrix A, Matrix B) {
+    protected void assertMatrixEquals(Matrix A, Matrix B) {
         assertEquals(A.numRows(), B.numRows());
         assertEquals(A.numColumns(), B.numColumns());
         for (int i = 0; i < A.numRows(); ++i) {

--- a/src/test/java/no/uib/cipr/matrix/QRTest.java
+++ b/src/test/java/no/uib/cipr/matrix/QRTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,65 +20,67 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.QR;
+import org.junit.Test;
 
 /**
  * QR test
  */
 public class QRTest extends OrthogonalTestAbstract {
 
-    public QRTest(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     public void testStaticFactorize() {
-        assertEquals(A, QR.factorize(A));
+        assertEqualsQR(A, QR.factorize(A));
     }
 
+    @Test
     public void testRepeatStaticFactorize() {
-        assertEquals(A, QR.factorize(A));
-        assertEquals(A, QR.factorize(A));
+        assertEqualsQR(A, QR.factorize(A));
+        assertEqualsQR(A, QR.factorize(A));
     }
 
+    @Test
     public void testFactor() {
         QR qr = new QR(A.numRows(), A.numColumns());
-        assertEquals(A, qr.factor(new DenseMatrix(A)));
+        assertEqualsQR(A, qr.factor(new DenseMatrix(A)));
     }
 
+    @Test
     public void testRepeatFactor() {
         QR qr = new QR(A.numRows(), A.numColumns());
         qr.factor(new DenseMatrix(A));
-        assertEquals(A, qr);
+        assertEqualsQR(A, qr);
         qr.factor(new DenseMatrix(A));
-        assertEquals(A, qr);
+        assertEqualsQR(A, qr);
     }
 
+    @Test
     public void testStaticFactorizeNonSquare() {
-        assertEquals(Ar, QR.factorize(Ar));
+        assertEqualsQR(Ar, QR.factorize(Ar));
     }
 
+    @Test
     public void testRepeatStaticFactorizeNonSquare() {
-        assertEquals(Ar, QR.factorize(Ar));
-        assertEquals(Ar, QR.factorize(Ar));
+        assertEqualsQR(Ar, QR.factorize(Ar));
+        assertEqualsQR(Ar, QR.factorize(Ar));
     }
 
+    @Test
     public void testFactorNonSquare() {
         QR qr = new QR(Ar.numRows(), Ar.numColumns());
-        assertEquals(Ar, qr.factor(new DenseMatrix(Ar)));
+        assertEqualsQR(Ar, qr.factor(new DenseMatrix(Ar)));
     }
 
+    @Test
     public void testRepeatFactorNonSquare() {
         QR qr = new QR(Ar.numRows(), Ar.numColumns());
         qr.factor(new DenseMatrix(Ar));
-        assertEquals(Ar, qr);
+        assertEqualsQR(Ar, qr);
         qr.factor(new DenseMatrix(Ar));
-        assertEquals(Ar, qr);
+        assertEqualsQR(Ar, qr);
     }
 
-    private void assertEquals(Matrix A, QR qr) {
-        assertEquals(A, qr.getQ().mult(qr.getR(), A.copy().zero()));
+    private void assertEqualsQR(Matrix A, QR qr) {
+        assertMatrixEquals(A, qr.getQ().mult(qr.getR(), A.copy().zero()));
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/RQTest.java
+++ b/src/test/java/no/uib/cipr/matrix/RQTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,65 +20,67 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.RQ;
+import org.junit.Test;
 
 /**
  * RQ test
  */
 public class RQTest extends OrthogonalTestAbstract {
 
-    public RQTest(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     public void testStaticFactorize() {
-        assertEquals(A, RQ.factorize(A));
+        assertEqualsRQ(A, RQ.factorize(A));
     }
 
+    @Test
     public void testRepeatStaticFactorize() {
-        assertEquals(A, RQ.factorize(A));
-        assertEquals(A, RQ.factorize(A));
+        assertEqualsRQ(A, RQ.factorize(A));
+        assertEqualsRQ(A, RQ.factorize(A));
     }
 
+    @Test
     public void testFactor() {
         RQ c = new RQ(A.numRows(), A.numColumns());
-        assertEquals(A, c.factor(new DenseMatrix(A)));
+        assertEqualsRQ(A, c.factor(new DenseMatrix(A)));
     }
 
+    @Test
     public void testRepeatFactor() {
         RQ rq = new RQ(A.numRows(), A.numColumns());
         rq.factor(new DenseMatrix(A));
-        assertEquals(A, rq);
+        assertEqualsRQ(A, rq);
         rq.factor(new DenseMatrix(A));
-        assertEquals(A, rq);
+        assertEqualsRQ(A, rq);
     }
 
+    @Test
     public void testStaticFactorizeNonSquare() {
-        assertEquals(Ac, RQ.factorize(Ac));
+        assertEqualsRQ(Ac, RQ.factorize(Ac));
     }
 
+    @Test
     public void testRepeatStaticFactorizeNonSquare() {
-        assertEquals(Ac, RQ.factorize(Ac));
-        assertEquals(Ac, RQ.factorize(Ac));
+        assertEqualsRQ(Ac, RQ.factorize(Ac));
+        assertEqualsRQ(Ac, RQ.factorize(Ac));
     }
 
+    @Test
     public void testFactorNonSquare() {
         RQ rq = new RQ(Ac.numRows(), Ac.numColumns());
-        assertEquals(Ac, rq.factor(new DenseMatrix(Ac)));
+        assertEqualsRQ(Ac, rq.factor(new DenseMatrix(Ac)));
     }
 
+    @Test
     public void testRepeatFactorNonSquare() {
         RQ rq = new RQ(Ac.numRows(), Ac.numColumns());
         rq.factor(new DenseMatrix(Ac));
-        assertEquals(Ac, rq);
+        assertEqualsRQ(Ac, rq);
         rq.factor(new DenseMatrix(Ac));
-        assertEquals(Ac, rq);
+        assertEqualsRQ(Ac, rq);
     }
 
-    private void assertEquals(Matrix A, RQ rq) {
-        assertEquals(A, rq.getR().mult(rq.getQ(), A.copy().zero()));
+    private void assertEqualsRQ(Matrix A, RQ rq) {
+        assertMatrixEquals(A, rq.getR().mult(rq.getQ(), A.copy().zero()));
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/SPDTridiagMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SPDTridiagMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.SPDTridiagMatrix;
-
 /**
  * Test of symmetrical, positive definite tridiagonal matrices
  */
 public class SPDTridiagMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public SPDTridiagMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/SingularvalueTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SingularvalueTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,16 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.NotConvergedException;
-import no.uib.cipr.matrix.SVD;
-import no.uib.cipr.matrix.TridiagMatrix;
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test the singular value solver
  */
-public class SingularvalueTest extends TestCase {
+public class SingularvalueTest {
 
     /**
      * Matrix to decompose
@@ -42,31 +41,29 @@ public class SingularvalueTest extends TestCase {
      */
     private final int max = 100;
 
-    public SingularvalueTest(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
         A = new DenseMatrix(n, n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         A = null;
     }
 
+    @Test
     public void testStaticFactorize() throws NotConvergedException {
-        assertEquals(A, SVD.factorize(A));
+        assertEqualsSVD(A, SVD.factorize(A));
     }
 
+    @Test
     public void testFactor() throws NotConvergedException {
         SVD svd = new SVD(A.numRows(), A.numColumns());
-        assertEquals(A, svd.factor(A.copy()));
+        assertEqualsSVD(A, svd.factor(A.copy()));
     }
 
-    private void assertEquals(Matrix A, SVD svd) {
+    private void assertEqualsSVD(Matrix A, SVD svd) {
         TridiagMatrix S = new TridiagMatrix(svd.getS().length);
         System.arraycopy(svd.getS(), 0, S.getDiagonal(), 0, svd.getS().length);
         DenseMatrix U = svd.getU();

--- a/src/test/java/no/uib/cipr/matrix/SquareDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SquareDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,11 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
-
 /**
  * Test of square dense matrices. This is done as some solvers change for square
  * matrices (LU and QR)
  */
 public class SquareDenseMatrixTest extends MatrixTestAbstract {
-
-    public SquareDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/StructImmutableMatrixTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/StructImmutableMatrixTestAbstract.java
@@ -1,24 +1,26 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
 package no.uib.cipr.matrix;
+
+import org.junit.Test;
 
 /**
  * Test of a matrix whose structure cannot change, but its numerical values can
@@ -27,115 +29,133 @@ public abstract class StructImmutableMatrixTestAbstract
         extends
             MatrixTestAbstract {
 
-    public StructImmutableMatrixTestAbstract(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     @Override
     public void testMatrixAdd() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixSet() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testOneMatrixAdd() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testOneMatrixSet() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testRandomMatrixAdd() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testRandomMatrixSet() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testZeroMatrixAdd() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testZeroMatrixSet() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testVectorRank1() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testVectorRank1Dense() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testVectorRank2() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testVectorRank2Dense() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixRank1() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixRank1Dense() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixTransRank1Dense() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixTransRank1() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixRank2() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixRank2Dense() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixTransRank2() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixTransRank2Dense() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testTranspose() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testTransposeInplace() {
         // Not supported

--- a/src/test/java/no/uib/cipr/matrix/SymmBandEigenvalueTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmBandEigenvalueTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,12 +20,10 @@
 
 package no.uib.cipr.matrix;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
-
-import no.uib.cipr.matrix.LowerSymmBandMatrix;
-import no.uib.cipr.matrix.NotConvergedException;
-import no.uib.cipr.matrix.SymmBandEVD;
-import no.uib.cipr.matrix.UpperSymmBandMatrix;
+import org.junit.Test;
 
 /**
  * Test of the symmetric, tridiagonal eigenvalue solver
@@ -36,63 +34,67 @@ public class SymmBandEigenvalueTest extends SymmEigenvalueTestAbstract {
 
     private UpperSymmBandMatrix U;
 
-    public SymmBandEigenvalueTest(String arg0) {
-        super(arg0);
-    }
-
+    @Before
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         int kd = Utilities.getInt(1, A.numRows());
         L = new LowerSymmBandMatrix(A, kd);
         U = new UpperSymmBandMatrix(A, kd);
     }
 
+    @After
     @Override
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
         L = null;
         U = null;
     }
 
+    @Test
     public void testLowerStaticFactorize() throws NotConvergedException {
         SymmBandEVD evd = SymmBandEVD.factorize(L, L.numSubDiagonals());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperStaticFactorize() throws NotConvergedException {
         SymmBandEVD evd = SymmBandEVD.factorize(U, U.numSuperDiagonals());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testLowerFactor() throws NotConvergedException {
         SymmBandEVD evd = new SymmBandEVD(A.numRows(), false);
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperFactor() throws NotConvergedException {
         SymmBandEVD evd = new SymmBandEVD(A.numRows(), true);
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
     @Ignore
+    @Test
     public void testLowerRepeatFactor() throws NotConvergedException {
         SymmBandEVD evd = new SymmBandEVD(A.numRows(), false);
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
     @Ignore
+    @Test
     public void testUpperRepeatFactor() throws NotConvergedException {
         SymmBandEVD evd = new SymmBandEVD(A.numRows(), true);
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/SymmDenseEigenvalueTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmDenseEigenvalueTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,10 +20,9 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSymmDenseMatrix;
-import no.uib.cipr.matrix.NotConvergedException;
-import no.uib.cipr.matrix.SymmDenseEVD;
-import no.uib.cipr.matrix.UpperSymmDenseMatrix;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test of the symmetric, dense eigenvalue solver
@@ -34,60 +33,64 @@ public class SymmDenseEigenvalueTest extends SymmEigenvalueTestAbstract {
 
     private UpperSymmDenseMatrix U;
 
-    public SymmDenseEigenvalueTest(String arg0) {
-        super(arg0);
-    }
-
+    @Before
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         L = new LowerSymmDenseMatrix(A);
         U = new UpperSymmDenseMatrix(A);
     }
 
+    @After
     @Override
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
         L = null;
         U = null;
     }
 
+    @Test
     public void testLowerStaticFactorize() throws NotConvergedException {
         SymmDenseEVD evd = SymmDenseEVD.factorize(L);
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperStaticFactorize() throws NotConvergedException {
         SymmDenseEVD evd = SymmDenseEVD.factorize(U);
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testLowerFactor() throws NotConvergedException {
         SymmDenseEVD evd = new SymmDenseEVD(A.numRows(), false);
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperFactor() throws NotConvergedException {
         SymmDenseEVD evd = new SymmDenseEVD(A.numRows(), true);
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testLowerRepeatFactor() throws NotConvergedException {
         SymmDenseEVD evd = new SymmDenseEVD(A.numRows(), false);
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperRepeatFactor() throws NotConvergedException {
         SymmDenseEVD evd = new SymmDenseEVD(A.numRows(), true);
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/SymmEigenvalueTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmEigenvalueTestAbstract.java
@@ -20,15 +20,15 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.Matrix;
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the symmetric eigenvalue computers
  */
-public abstract class SymmEigenvalueTestAbstract extends TestCase {
+public abstract class SymmEigenvalueTestAbstract {
 
     /**
      * Initial work-matrix
@@ -40,22 +40,18 @@ public abstract class SymmEigenvalueTestAbstract extends TestCase {
      */
     private final int max = 100;
 
-    public SymmEigenvalueTestAbstract(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
         A = Matrices.random(n, n);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         A = null;
     }
 
-    protected void assertEquals(Matrix A, double[] w, DenseMatrix Z) {
+    protected void assertEqualsWZ(Matrix A, double[] w, DenseMatrix Z) {
         // A*X
         Matrix left = A.mult(Z, new DenseMatrix(A.numRows(), A.numColumns()));
 

--- a/src/test/java/no/uib/cipr/matrix/SymmPackEigenvalueTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmPackEigenvalueTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,10 +20,9 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.LowerSymmPackMatrix;
-import no.uib.cipr.matrix.NotConvergedException;
-import no.uib.cipr.matrix.SymmPackEVD;
-import no.uib.cipr.matrix.UpperSymmPackMatrix;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test of the symmetric, dense eigenvalue solver
@@ -34,60 +33,64 @@ public class SymmPackEigenvalueTest extends SymmEigenvalueTestAbstract {
 
     private UpperSymmPackMatrix U;
 
-    public SymmPackEigenvalueTest(String arg0) {
-        super(arg0);
-    }
-
+    @Before
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         L = new LowerSymmPackMatrix(A);
         U = new UpperSymmPackMatrix(A);
     }
 
+    @After
     @Override
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
         L = null;
         U = null;
     }
 
+    @Test
     public void testLowerStaticFactorize() throws NotConvergedException {
         SymmPackEVD evd = SymmPackEVD.factorize(L);
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperStaticFactorize() throws NotConvergedException {
         SymmPackEVD evd = SymmPackEVD.factorize(U);
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testLowerFactor() throws NotConvergedException {
         SymmPackEVD evd = new SymmPackEVD(A.numRows(), false);
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperFactor() throws NotConvergedException {
         SymmPackEVD evd = new SymmPackEVD(A.numRows(), true);
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testLowerRepeatFactor() throws NotConvergedException {
         SymmPackEVD evd = new SymmPackEVD(A.numRows(), false);
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
         evd.factor(L.copy());
-        assertEquals(L, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(L, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testUpperRepeatFactor() throws NotConvergedException {
         SymmPackEVD evd = new SymmPackEVD(A.numRows(), true);
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
         evd.factor(U.copy());
-        assertEquals(U, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(U, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/SymmTridiagEigenvalueTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmTridiagEigenvalueTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,10 +20,8 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.NotConvergedException;
-import no.uib.cipr.matrix.SymmTridiagEVD;
-import no.uib.cipr.matrix.SymmTridiagMatrix;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test of the symmetric, tridiagonal eigenvalue solver
@@ -34,34 +32,34 @@ public class SymmTridiagEigenvalueTest extends SymmEigenvalueTestAbstract {
 
     private final int max = 100;
 
-    public SymmTridiagEigenvalueTest(String arg0) {
-        super(arg0);
-    }
-
+    @Before
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         int n = Utilities.getInt(1, max);
         A = Matrices.random(n, n);
         T = new SymmTridiagMatrix(A);
     }
 
+    @Test
     public void testStaticFactorize() throws NotConvergedException {
         SymmTridiagEVD evd = SymmTridiagEVD.factorize(A);
-        assertEquals(T, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(T, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testFactor() throws NotConvergedException {
         SymmTridiagEVD evd = new SymmTridiagEVD(A.numRows());
         evd.factor(T.copy());
-        assertEquals(T, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(T, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
+    @Test
     public void testRepeatFactor() throws NotConvergedException {
         SymmTridiagEVD evd = new SymmTridiagEVD(A.numRows());
         evd.factor(T.copy());
-        assertEquals(T, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(T, evd.getEigenvalues(), evd.getEigenvectors());
         evd.factor(T.copy());
-        assertEquals(T, evd.getEigenvalues(), evd.getEigenvectors());
+        assertEqualsWZ(T, evd.getEigenvalues(), evd.getEigenvectors());
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/SymmTridiagMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmTridiagMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.SymmTridiagMatrix;
-
 /**
  * Test of SymmTridiagMatrix
  */
 public class SymmTridiagMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public SymmTridiagMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/SymmetricMatrixTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/SymmetricMatrixTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,58 +20,64 @@
 
 package no.uib.cipr.matrix;
 
+import org.junit.Test;
+
 /**
  * Test of symmetrical matrices
  */
 public abstract class SymmetricMatrixTestAbstract extends MatrixTestAbstract {
 
-    public SymmetricMatrixTestAbstract(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     @Override
     public void testMatrixAdd() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testMatrixSet() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testOneMatrixAdd() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testOneMatrixSet() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testRandomMatrixAdd() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testRandomMatrixSet() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testVectorRank1() {
         if (A.isSquare()) {
             double alpha = Math.random();
-            assertEquals(rank1(alpha, xdR, xdR), A.rank1(alpha, xR, xR));
+            assertMatrixEquals(rank1(alpha, xdR, xdR), A.rank1(alpha, xR, xR));
         }
     }
 
+    @Test
     @Override
     public void testVectorRank1Dense() {
         if (A.isSquare()) {
             double alpha = Math.random();
-            assertEquals(rank1(alpha, xdR, xdR),
+            assertMatrixEquals(rank1(alpha, xdR, xdR),
                     A.rank1(alpha, xDenseR, xDenseR));
         }
     }

--- a/src/test/java/no/uib/cipr/matrix/TriangMatrixTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/TriangMatrixTestAbstract.java
@@ -1,24 +1,26 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
 package no.uib.cipr.matrix;
+
+import org.junit.Test;
 
 /**
  * Test of triangular matrices
@@ -27,10 +29,7 @@ public abstract class TriangMatrixTestAbstract
         extends
             StructImmutableMatrixTestAbstract {
 
-    public TriangMatrixTestAbstract(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     @Override
     public void testTransposeInplace() {
         // Not supported

--- a/src/test/java/no/uib/cipr/matrix/TridiagMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/TridiagMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,12 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.TridiagMatrix;
+import org.junit.Test;
 
 /**
  * Test of tridiagonal matrices
  */
 public class TridiagMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public TridiagMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {
@@ -38,11 +34,13 @@ public class TridiagMatrixTest extends StructImmutableMatrixTestAbstract {
         Ad = Utilities.bandPopulate(A, 1, 1);
     }
 
+    @Test
     @Override
     public void testTransMatrixSolve() {
         // Not supported
     }
 
+    @Test
     @Override
     public void testTransVectorSolve() {
         // Not supported

--- a/src/test/java/no/uib/cipr/matrix/UnitLowerTriangBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UnitLowerTriangBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UnitLowerTriangBandMatrix;
-
 /**
  * Test of UnitLowerTriangBandMatrix
  */
 public class UnitLowerTriangBandMatrixTest extends UnitTriangMatrixTestAbstract {
-
-    public UnitLowerTriangBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UnitLowerTriangDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UnitLowerTriangDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,14 @@
 
 package no.uib.cipr.matrix;
 
+import org.junit.Test;
+
 /**
  * Test of UnitLowerTriangDenseMatrix
  */
 public class UnitLowerTriangDenseMatrixTest
         extends
             UnitTriangMatrixTestAbstract {
-
-    public UnitLowerTriangDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {
@@ -39,6 +37,7 @@ public class UnitLowerTriangDenseMatrixTest
         Utilities.unitSet(Ad);
     }
 
+    @Test
     public void testMultUpper() {
         Matrix lu = new DenseMatrix(new double[][]{{-4.00, 6.00, 3.00},
                 {1.00, -8.00, 5.00}, {-0.50, -0.25, 0.75}});
@@ -49,7 +48,7 @@ public class UnitLowerTriangDenseMatrixTest
                 {2, -1, -2}});
 
         Matrix out = l.mult(u, new DenseMatrix(3, 3));
-        MatrixTestAbstract.assertEquals(e, out);
+        MatrixTestAbstract.assertMatrixEquals(e, out);
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/UnitLowerTriangPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UnitLowerTriangPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UnitLowerTriangPackMatrix;
-
 /**
  * Test of UnitLowerTriangPackMatrix
  */
 public class UnitLowerTriangPackMatrixTest extends UnitTriangMatrixTestAbstract {
-
-    public UnitLowerTriangPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UnitTriangMatrixTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/UnitTriangMatrixTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,8 +20,7 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.MatrixEntry;
+import org.junit.Test;
 
 /**
  * Test of unit, triangular matrices
@@ -30,46 +29,50 @@ public abstract class UnitTriangMatrixTestAbstract
         extends
             TriangMatrixTestAbstract {
 
-    public UnitTriangMatrixTestAbstract(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     public void testAddDiagonal() {
         // Not applicable to unit triangular matrices
     }
 
+    @Test
     public void testAddOneDiagonal() {
         // Not applicable to unit triangular matrices
     }
 
+    @Test
     public void testAddZeroDiagonal() {
         // Not applicable to unit triangular matrices
     }
 
+    @Test
     @Override
     public void testIteratorSet() {
         double alpha = Math.random();
         for (MatrixEntry e : A)
             if (e.row() != e.column())
                 e.set(e.get() * alpha);
-        assertEquals(Utilities.unitSet(scale(alpha)), A);
+        assertMatrixEquals(Utilities.unitSet(scale(alpha)), A);
     }
 
+    @Test
     @Override
     public void testIteratorSetGet() {
         // Not applicable to unit triangular matrices
     }
 
+    @Test
     @Override
     public void testScale() {
         // Not applicable to unit triangular matrices
     }
 
+    @Test
     @Override
     public void testZero() {
         // Not applicable to unit triangular matrices
     }
 
+    @Test
     @Override
     public void testZeroScale() {
         // Not applicable to unit triangular matrices
@@ -78,12 +81,14 @@ public abstract class UnitTriangMatrixTestAbstract
     /**
      * We can't zero, so we do without
      */
+    @Test
     @Override
     public void testCopy() {
         Matrix Ac = A.copy();
-        assertEquals(Ad, Ac);
+        assertMatrixEquals(Ad, Ac);
     }
 
+    @Test
     @Override
     public void testAdd() {
         double alpha = Math.random();
@@ -92,7 +97,7 @@ public abstract class UnitTriangMatrixTestAbstract
                 A.add(e.row(), e.column(), alpha);
                 A.add(e.row(), e.column(), -alpha);
             }
-        assertEquals(Ad, A);
+        assertMatrixEquals(Ad, A);
     }
 
 }

--- a/src/test/java/no/uib/cipr/matrix/UnitUpperTriangBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UnitUpperTriangBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UnitUpperTriangBandMatrix;
-
 /**
  * Test of UnitUpperTriangBandMatrix
  */
 public class UnitUpperTriangBandMatrixTest extends UnitTriangMatrixTestAbstract {
-
-    public UnitUpperTriangBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UnitUpperTriangDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UnitUpperTriangDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,18 +20,12 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UnitUpperTriangDenseMatrix;
-
 /**
  * Test of UnitUpperTriangDenseMatrix
  */
 public class UnitUpperTriangDenseMatrixTest
         extends
             UnitTriangMatrixTestAbstract {
-
-    public UnitUpperTriangDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UnitUpperTriangPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UnitUpperTriangPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UnitUpperTriangPackMatrix;
-
 /**
  * Test of UnitUpperTriangPackMatrix
  */
 public class UnitUpperTriangPackMatrixTest extends UnitTriangMatrixTestAbstract {
-
-    public UnitUpperTriangPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperSPDBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperSPDBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperSPDBandMatrix;
-
 /**
  * Test of UpperSPDBandMatrix
  */
 public class UpperSPDBandMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public UpperSPDBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperSPDDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperSPDDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperSPDDenseMatrix;
-
 /**
  * Test of UpperSPDDenseMatrix
  */
 public class UpperSPDDenseMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public UpperSPDDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperSPDPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperSPDPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperSPDPackMatrix;
-
 /**
  * Test of UpperSPDPackMatrix
  */
 public class UpperSPDPackMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public UpperSPDPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperSymmBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperSymmBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperSymmBandMatrix;
-
 /**
  * Test of UpperSymmBandMatrix
  */
 public class UpperSymmBandMatrixTest extends StructImmutableMatrixTestAbstract {
-
-    public UpperSymmBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperSymmDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperSymmDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperSymmDenseMatrix;
-
 /**
  * Test of UpperSymmDenseMatrix
  */
 public class UpperSymmDenseMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public UpperSymmDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperSymmPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperSymmPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperSymmPackMatrix;
-
 /**
  * Test of UpperSymmPackMatrixTest
  */
 public class UpperSymmPackMatrixTest extends SymmetricMatrixTestAbstract {
-
-    public UpperSymmPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperTriangBandMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperTriangBandMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperTriangBandMatrix;
-
 /**
  * Test of UpperTriangBandMatrix
  */
 public class UpperTriangBandMatrixTest extends TriangMatrixTestAbstract {
-
-    public UpperTriangBandMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperTriangDenseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperTriangDenseMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperTriangDenseMatrix;
-
 /**
  * Test of UpperTriangDenseMatrix
  */
 public class UpperTriangDenseMatrixTest extends TriangMatrixTestAbstract {
-
-    public UpperTriangDenseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/UpperTriangPackMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/UpperTriangPackMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix;
 
-import no.uib.cipr.matrix.UpperTriangPackMatrix;
-
 /**
  * Test of UpperTriangPackMatrix
  */
 public class UpperTriangPackMatrixTest extends TriangMatrixTestAbstract {
-
-    public UpperTriangPackMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/VectorTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/VectorTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,13 +20,17 @@
 
 package no.uib.cipr.matrix;
 
-import junit.framework.TestCase;
 import no.uib.cipr.matrix.Vector.Norm;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of vectors
  */
-public abstract class VectorTestAbstract extends TestCase {
+public abstract class VectorTestAbstract {
 
     /**
      * Max vector size
@@ -58,12 +62,8 @@ public abstract class VectorTestAbstract extends TestCase {
      */
     protected double tol = 1e-5;
 
-    public VectorTestAbstract(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         createPrimary();
         createAuxillerary();
     }
@@ -79,38 +79,44 @@ public abstract class VectorTestAbstract extends TestCase {
         zd = Matrices.getArray(z);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         x = null;
         xd = null;
     }
 
+    @Test
     public void testSize() {
         assertEquals(xd.length, x.size());
     }
 
+    @Test
     public void testCopy() {
         Vector y = x.copy();
-        assertEquals(xd, y);
+        assertVectorEquals(xd, y);
         y.scale(Math.random());
-        assertEquals(xd, x);
+        assertVectorEquals(xd, x);
     }
 
+    @Test
     public void testZero() {
-        assertEquals(scale(0), x.zero());
+        assertVectorEquals(scale(0), x.zero());
     }
 
+    @Test
     public void testScale() {
         double alpha = Math.random();
-        assertEquals(scale(alpha), x.scale(alpha));
+        assertVectorEquals(scale(alpha), x.scale(alpha));
     }
 
+    @Test
     public void testScaleZero() {
-        assertEquals(scale(0), x.scale(0));
+        assertVectorEquals(scale(0), x.scale(0));
     }
 
+    @Test
     public void testScaleOne() {
-        assertEquals(scale(1), x.scale(1));
+        assertVectorEquals(scale(1), x.scale(1));
     }
 
     protected double[] scale(double alpha) {
@@ -122,31 +128,35 @@ public abstract class VectorTestAbstract extends TestCase {
     /*
      * Test for Vector set(Vector)
      */
+    @Test
     public void testSetVectorDense() {
-        assertEquals(set(1, yd, 0, zd), x.set(yDense));
+        assertVectorEquals(set(1, yd, 0, zd), x.set(yDense));
     }
 
     /*
      * Test for Vector set(double, Vector)
      */
+    @Test
     public void testSetdoubleVectorDense() {
         double alpha = Math.random();
-        assertEquals(set(alpha, yd, 0, zd), x.set(alpha, yDense));
+        assertVectorEquals(set(alpha, yd, 0, zd), x.set(alpha, yDense));
     }
 
     /*
      * Test for Vector set(Vector)
      */
+    @Test
     public void testSetVector() {
-        assertEquals(set(1, yd, 0, zd), x.set(y));
+        assertVectorEquals(set(1, yd, 0, zd), x.set(y));
     }
 
     /*
      * Test for Vector set(double, Vector)
      */
+    @Test
     public void testSetDoubleVector() {
         double alpha = Math.random();
-        assertEquals(set(alpha, yd, 0, zd), x.set(alpha, y));
+        assertVectorEquals(set(alpha, yd, 0, zd), x.set(alpha, y));
     }
 
     protected double[] set(double alpha, double[] yd, double beta, double[] zd) {
@@ -158,31 +168,35 @@ public abstract class VectorTestAbstract extends TestCase {
     /*
      * Test for Vector add(double, Vector)
      */
+    @Test
     public void testAddDoubleVectorDense() {
         double alpha = Math.random();
-        assertEquals(add(alpha, yd), x.add(alpha, yDense));
+        assertVectorEquals(add(alpha, yd), x.add(alpha, yDense));
     }
 
     /*
      * Test for Vector add(Vector)
      */
+    @Test
     public void testAddVectorDense() {
-        assertEquals(add(1, yd), x.add(yDense));
+        assertVectorEquals(add(1, yd), x.add(yDense));
     }
 
     /*
      * Test for Vector add(double, Vector)
      */
+    @Test
     public void testAddDoubleVector() {
         double alpha = Math.random();
-        assertEquals(add(alpha, yd), x.add(alpha, y));
+        assertVectorEquals(add(alpha, yd), x.add(alpha, y));
     }
 
     /*
      * Test for Vector add(Vector)
      */
+    @Test
     public void testAddVector() {
-        assertEquals(add(1, yd), x.add(y));
+        assertVectorEquals(add(1, yd), x.add(y));
     }
 
     protected double[] add(double alpha, double[] yd) {
@@ -191,16 +205,18 @@ public abstract class VectorTestAbstract extends TestCase {
         return xd;
     }
 
+    @Test
     public void testDotDense() {
         assertEquals(dot(yd), x.dot(yDense), tol);
-        assertEquals(xd, x);
-        assertEquals(yd, yDense);
+        assertVectorEquals(xd, x);
+        assertVectorEquals(yd, yDense);
     }
 
+    @Test
     public void testDot() {
         assertEquals(dot(yd), x.dot(y), tol);
-        assertEquals(xd, x);
-        assertEquals(yd, y);
+        assertVectorEquals(xd, x);
+        assertVectorEquals(yd, y);
     }
 
     protected double dot(double[] yd) {
@@ -210,6 +226,7 @@ public abstract class VectorTestAbstract extends TestCase {
         return dot;
     }
 
+    @Test
     public void testCardinality() {
         assertEquals(cardinality(), Matrices.cardinality(x));
     }
@@ -222,14 +239,17 @@ public abstract class VectorTestAbstract extends TestCase {
         return nz;
     }
 
+    @Test
     public void testNorm1() {
         assertEquals(norm1(), x.norm(Norm.One), tol);
     }
 
+    @Test
     public void testNorm2() {
         assertEquals(norm2(), x.norm(Norm.Two), tol);
     }
 
+    @Test
     public void testNormInf() {
         assertEquals(normInf(), x.norm(Norm.Infinity), tol);
     }
@@ -255,6 +275,7 @@ public abstract class VectorTestAbstract extends TestCase {
         return norm;
     }
 
+    @Test
     public void testIteratorSetGet() {
         double alpha = Math.random();
         double[] data = new double[x.size()];
@@ -263,32 +284,34 @@ public abstract class VectorTestAbstract extends TestCase {
             e.set(alpha * e.get());
             e.set(e.get() / alpha);
         }
-        assertEquals(xd, x);
-        assertEquals(xd, data);
+        assertVectorEquals(xd, x);
+        assertVectorEquals(xd, data);
     }
 
+    @Test
     public void testIteratorGet() {
         double[] data = new double[x.size()];
         for (VectorEntry e : x)
             data[e.index()] = e.get();
-        assertEquals(xd, x);
-        assertEquals(xd, data);
+        assertVectorEquals(xd, x);
+        assertVectorEquals(xd, data);
     }
 
+    @Test
     public void testIteratorSet() {
         double alpha = Math.random();
         for (VectorEntry e : x)
             e.set(alpha * e.get());
-        assertEquals(scale(alpha), x);
+        assertVectorEquals(scale(alpha), x);
     }
 
-    protected void assertEquals(double[] xd, Vector x) {
+    protected void assertVectorEquals(double[] xd, Vector x) {
         assertEquals(xd.length, x.size());
         for (int i = 0; i < xd.length; ++i)
             assertEquals(xd[i], x.get(i), tol);
     }
 
-    protected void assertEquals(double[] xd, double[] yd) {
+    protected void assertVectorEquals(double[] xd, double[] yd) {
         for (int i = 0; i < xd.length; ++i)
             assertEquals(xd[i], yd[i], tol);
     }

--- a/src/test/java/no/uib/cipr/matrix/io/MatrixVectorIoTest.java
+++ b/src/test/java/no/uib/cipr/matrix/io/MatrixVectorIoTest.java
@@ -1,18 +1,19 @@
 package no.uib.cipr.matrix.io;
 
-import junit.framework.TestCase;
 import no.uib.cipr.matrix.DenseMatrix;
 import no.uib.cipr.matrix.Matrix;
 import no.uib.cipr.matrix.MatrixTestAbstract;
 import no.uib.cipr.matrix.sparse.CompRowMatrix;
+import org.junit.Test;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 
-public class MatrixVectorIoTest extends TestCase {
+public class MatrixVectorIoTest {
 
+    @Test
     public void testWriteRead() throws Exception {
         DenseMatrix mat = new DenseMatrix(
                 new double[][]{{1.1, 1.2}, {1.3, 1.4}});
@@ -29,9 +30,10 @@ public class MatrixVectorIoTest extends TestCase {
         Matrix newMat = new DenseMatrix(new MatrixVectorReader(new FileReader(
                 matrixFile)));
 
-        MatrixTestAbstract.assertEquals(mat, newMat);
+        MatrixTestAbstract.assertMatrixEquals(mat, newMat);
     }
 
+    @Test
     public void testSparseWriteRead() throws Exception {
         CompRowMatrix mat = new CompRowMatrix(3, 3, new int[][]{{1, 2}, {0, 2},
                 {1}});
@@ -55,7 +57,7 @@ public class MatrixVectorIoTest extends TestCase {
         out.close();
         CompRowMatrix newMat = new CompRowMatrix(new MatrixVectorReader(
                 new FileReader(testFile)));
-        MatrixTestAbstract.assertEquals(mat, newMat);
+        MatrixTestAbstract.assertMatrixEquals(mat, newMat);
     }
 
     private int[] buildRowArray(CompRowMatrix mat) {

--- a/src/test/java/no/uib/cipr/matrix/sparse/ArpackSymTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ArpackSymTest.java
@@ -1,22 +1,25 @@
 package no.uib.cipr.matrix.sparse;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import lombok.extern.java.Log;
 import no.uib.cipr.matrix.*;
 import no.uib.cipr.matrix.io.MatrixVectorReader;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.FileReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 /**
  * @author Sam Halliday
  */
 @Log
-public class ArpackSymTest extends TestCase {
+public class ArpackSymTest {
 
+    @Test
     public void testRandomEigensystem() throws NotConvergedException {
         for (int i = 100; i <= 500; i = i + 100) {
             UpperSymmDenseMatrix matrix = new UpperSymmDenseMatrix(i);
@@ -28,7 +31,7 @@ public class ArpackSymTest extends TestCase {
 
             Map<Double, DenseVectorSub> results = solver.solve(todo,
                     ArpackSym.Ritz.LA);
-            Assert.assertEquals(todo, results.size());
+            assertEquals(todo, results.size());
             for (Map.Entry<Double, DenseVectorSub> e : results.entrySet()) {
                 // exact match of eigenvector / eigenvalue is not important for
                 // random matrices

--- a/src/test/java/no/uib/cipr/matrix/sparse/BiCGDiagonalTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/BiCGDiagonalTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.DiagonalPreconditioner;
-
 /**
  * Test of BiCG with diagonal preconditioning
  */
 public class BiCGDiagonalTest extends BiCGTest {
-
-    public BiCGDiagonalTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/BiCGILUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/BiCGILUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILU;
-
 /**
  * Test of BiCG with ILU
  */
 public class BiCGILUTest extends BiCGTest {
-
-    public BiCGILUTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/BiCGTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/BiCGTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.BiCG;
-
 /**
  * Test of BiCG
  */
 public class BiCGTest extends IterativeSolverTestAbstract {
-
-    public BiCGTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabDiagonalTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabDiagonalTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.DiagonalPreconditioner;
-
 /**
  * Test of BiCGstab with diagonal preconditioning
  */
 public class BiCGstabDiagonalTest extends BiCGstabTest {
-
-    public BiCGstabDiagonalTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabILUTTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabILUTTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.FlexCompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILUT;
-
 /**
  * Test of BiCGstab with ILUT
  */
 public class BiCGstabILUTTest extends BiCGstabTest {
-
-    public BiCGstabILUTTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabILUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabILUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILU;
-
 /**
  * Test of BiCGstab with ILU
  */
 public class BiCGstabILUTest extends BiCGstabTest {
-
-    public BiCGstabILUTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/BiCGstabTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.BiCGstab;
-
 /**
  * Test of BiCGstab
  */
 public class BiCGstabTest extends IterativeSolverTestAbstract {
-
-    public BiCGstabTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGAMGTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGAMGTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.AMG;
-
 /**
  * Test of CG with AMG
  */
 public class CGAMGTest extends CGTest {
-
-    public CGAMGTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGDiagonalTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGDiagonalTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.DiagonalPreconditioner;
-
 /**
  * Test of CG with diagonal preconditioning
  */
 public class CGDiagonalTest extends CGTest {
-
-    public CGDiagonalTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGICCTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGICCTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ICC;
-
 /**
  * Test of CG with ICC
  */
 public class CGICCTest extends CGTest {
-
-    public CGICCTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGSDiagonalTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGSDiagonalTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.DiagonalPreconditioner;
-
 /**
  * Test of CGS with diagonal preconditioning
  */
 public class CGSDiagonalTest extends CGSTest {
-
-    public CGSDiagonalTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGSILUTTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGSILUTTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.FlexCompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILUT;
-
 /**
  * Test of CGS with ILUT
  */
 public class CGSILUTTest extends CGSTest {
-
-    public CGSILUTTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGSILUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGSILUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILU;
-
 /**
  * Test of CGS with ILU
  */
 public class CGSILUTest extends CGSTest {
-
-    public CGSILUTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGSSORTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGSSORTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.SSOR;
-
 /**
  * Test of CG with SSOR
  */
 public class CGSSORTest extends CGTest {
-
-    public CGSSORTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGSTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGSTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CGS;
-
 /**
  * Test of CGS
  */
 public class CGSTest extends IterativeSolverTestAbstract {
-
-    public CGSTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CGTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CGTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CG;
-
 /**
  * Test of CG
  */
 public class CGTest extends SPDIterativeSolverTestAbstract {
-
-    public CGTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevAMGTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevAMGTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.AMG;
-
 /**
  * Test of Chebyshev with AMG
  */
 public class ChebyshevAMGTest extends ChebyshevTest {
-
-    public ChebyshevAMGTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevDiagonalTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevDiagonalTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.DiagonalPreconditioner;
-
 /**
  * Test of Chebyshev with diagonal preconditioning
  */
 public class ChebyshevDiagonalTest extends ChebyshevTest {
-
-    public ChebyshevDiagonalTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevICCTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevICCTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ICC;
-
 /**
  * Test of Chebyshev with ICC
  */
 public class ChebyshevICCTest extends ChebyshevTest {
-
-    public ChebyshevICCTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevSSORTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevSSORTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.SSOR;
-
 /**
  * Test of Chebyshev with SSOR preconditioning
  */
 public class ChebyshevSSORTest extends ChebyshevTest {
-
-    public ChebyshevSSORTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ChebyshevTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -21,16 +21,11 @@
 package no.uib.cipr.matrix.sparse;
 
 import no.uib.cipr.matrix.SymmDenseEVD;
-import no.uib.cipr.matrix.sparse.Chebyshev;
 
 /**
  * Test of Chebyshev solver
  */
 public class ChebyshevTest extends SPDIterativeSolverTestAbstract {
-
-    public ChebyshevTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CompColMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CompColMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,12 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompColMatrix;
 import no.uib.cipr.matrix.Utilities;
 
 /**
  * Test of CompColMatrix
  */
 public class CompColMatrixTest extends SparseStructImmutableMatrixTestAbstract {
-
-    public CompColMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CompDiagMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CompDiagMatrixTest.java
@@ -1,35 +1,30 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompDiagMatrix;
 import no.uib.cipr.matrix.Utilities;
 
 /**
  * Test of CompDiagMatrix
  */
 public class CompDiagMatrixTest extends SparseMatrixTestAbstract {
-
-    public CompDiagMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/CompRowMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/CompRowMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,12 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
 import no.uib.cipr.matrix.Utilities;
 
 /**
  * Test of CompRowMatrix
  */
 public class CompRowMatrixTest extends SparseStructImmutableMatrixTestAbstract {
-
-    public CompRowMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/FlexCompColMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/FlexCompColMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,12 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.FlexCompColMatrix;
 import no.uib.cipr.matrix.Utilities;
 
 /**
  * Test of FlexCompColMatrix
  */
 public class FlexCompColMatrixTest extends SparseMatrixTestAbstract {
-
-    public FlexCompColMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/FlexCompRowMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/FlexCompRowMatrixTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,12 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.FlexCompRowMatrix;
 import no.uib.cipr.matrix.Utilities;
 
 /**
  * Test of FlexCompRowMatrix
  */
 public class FlexCompRowMatrixTest extends SparseMatrixTestAbstract {
-
-    public FlexCompRowMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/GMRESDiagonalTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/GMRESDiagonalTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.DiagonalPreconditioner;
-
 /**
  * Test of GMRES with diagonal preconditioning
  */
 public class GMRESDiagonalTest extends GMRESTest {
-
-    public GMRESDiagonalTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/GMRESILUTTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/GMRESILUTTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.FlexCompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILUT;
-
 /**
  * Test of GMRES with ILUT
  */
 public class GMRESILUTTest extends GMRESTest {
-
-    public GMRESILUTTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/GMRESILUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/GMRESILUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILU;
-
 /**
  * Test of GMRES with ILU
  */
 public class GMRESILUTest extends GMRESTest {
-
-    public GMRESILUTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/GMRESTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/GMRESTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.GMRES;
-
 /**
  * Test of GMRES
  */
 public class GMRESTest extends IterativeSolverTestAbstract {
-
-    public GMRESTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/ICCTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ICCTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -22,8 +22,8 @@ package no.uib.cipr.matrix.sparse;
 
 import no.uib.cipr.matrix.Matrix;
 import no.uib.cipr.matrix.Vector;
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ICC;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of ICC(0)

--- a/src/test/java/no/uib/cipr/matrix/sparse/ILUTTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ILUTTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -22,8 +22,9 @@ package no.uib.cipr.matrix.sparse;
 
 import no.uib.cipr.matrix.Matrix;
 import no.uib.cipr.matrix.Vector;
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILU;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of ILU with thresholding
@@ -47,6 +48,7 @@ public class ILUTTest extends IncompleteFactorizationTestAbstract {
      * Test for diagInd values exceeding row data array length after dropTol is
      * applied causing ArrayOutOfBounds Error
      */
+    @Test
     public void testILUTDropOutOfBoundsError() {
         int matrixSize = 100;
         FlexCompRowMatrix triDiagMatix = new FlexCompRowMatrix(matrixSize,

--- a/src/test/java/no/uib/cipr/matrix/sparse/ILUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/ILUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -22,8 +22,8 @@ package no.uib.cipr.matrix.sparse;
 
 import no.uib.cipr.matrix.Matrix;
 import no.uib.cipr.matrix.Vector;
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILU;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test of ILU(0)

--- a/src/test/java/no/uib/cipr/matrix/sparse/IncompleteFactorizationTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/IncompleteFactorizationTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,23 +20,15 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.DenseMatrix;
-import no.uib.cipr.matrix.DenseVector;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.Vector;
-import no.uib.cipr.matrix.Utilities;
-import junit.framework.TestCase;
+import no.uib.cipr.matrix.*;
+import org.junit.Test;
 
 /**
  * Test of incomplete factorizations
  */
-public abstract class IncompleteFactorizationTestAbstract extends TestCase {
+public abstract class IncompleteFactorizationTestAbstract {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
+    @Test
     public void testTriDiagonal() {
         int n = Utilities.getInt(1, 10);
         Matrix A = new DenseMatrix(n, n);
@@ -54,6 +46,7 @@ public abstract class IncompleteFactorizationTestAbstract extends TestCase {
         testFactorization(A, x);
     }
 
+    @Test
     public void testPentaDiagonal() {
         int n = Utilities.getInt(1, 10);
         Matrix A = new DenseMatrix(n, n);

--- a/src/test/java/no/uib/cipr/matrix/sparse/IterativeSolverTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/IterativeSolverTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,21 +20,18 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.DenseLU;
-import no.uib.cipr.matrix.Matrices;
-import no.uib.cipr.matrix.Matrix;
-import no.uib.cipr.matrix.Vector;
-import no.uib.cipr.matrix.sparse.FlexCompRowMatrix;
-import no.uib.cipr.matrix.sparse.IterativeSolver;
-import no.uib.cipr.matrix.sparse.IterativeSolverNotConvergedException;
-import no.uib.cipr.matrix.sparse.Preconditioner;
-import no.uib.cipr.matrix.Utilities;
-import junit.framework.TestCase;
+import no.uib.cipr.matrix.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Test of the iterative solvers and preconditioners
  */
-public abstract class IterativeSolverTestAbstract extends TestCase {
+public abstract class IterativeSolverTestAbstract {
 
     /**
      * Number of times to repeat tests
@@ -82,15 +79,8 @@ public abstract class IterativeSolverTestAbstract extends TestCase {
      */
     protected Preconditioner M;
 
-    /**
-     * Constructor for IterativeSolverTestAbstract
-     */
-    public IterativeSolverTestAbstract(String arg0) {
-        super(arg0);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         createMatrix();
 
         int n = A.numRows();
@@ -139,14 +129,15 @@ public abstract class IterativeSolverTestAbstract extends TestCase {
             A.add(i, i, shift);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         A = null;
         b = bt = x = null;
         xd = null;
         solver = null;
     }
 
+    @Test
     public void testSolve() {
         try {
             solver.solve(A, b, x);
@@ -157,6 +148,7 @@ public abstract class IterativeSolverTestAbstract extends TestCase {
         }
     }
 
+    @Test
     public void testRepeatSolve() {
         try {
             for (int i = 0; i < repeat; ++i) {

--- a/src/test/java/no/uib/cipr/matrix/sparse/LinkedSparseMatrixTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/LinkedSparseMatrixTest.java
@@ -3,26 +3,25 @@ package no.uib.cipr.matrix.sparse;
 import au.com.bytecode.opencsv.CSVWriter;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
-import junit.framework.Assert;
 import lombok.Cleanup;
 import lombok.extern.java.Log;
 import no.uib.cipr.matrix.DenseMatrix;
 import no.uib.cipr.matrix.Matrix;
 import no.uib.cipr.matrix.MatrixEntry;
 import no.uib.cipr.matrix.Utilities;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Sam Halliday
  */
 @Log
 public class LinkedSparseMatrixTest extends SparseMatrixTestAbstract {
-    public LinkedSparseMatrixTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {
@@ -37,14 +36,14 @@ public class LinkedSparseMatrixTest extends SparseMatrixTestAbstract {
             int row = e.row();
             int col = e.column();
             double expect = Ad[row][col];
-            Assert.assertEquals(expect, e.get(), 0);
-            Assert.assertEquals(expect, A.get(row, col), 0);
+            assertEquals(expect, e.get(), 0);
+            assertEquals(expect, A.get(row, col), 0);
         }
 
         for (int i = 0; i < n; i++) {
             for (int j = 0; j < m; j++) {
                 double expect = Ad[i][j];
-                Assert.assertEquals(expect, A.get(i, j), 0);
+                assertEquals(expect, A.get(i, j), 0);
             }
         }
 
@@ -52,13 +51,13 @@ public class LinkedSparseMatrixTest extends SparseMatrixTestAbstract {
         LinkedSparseMatrix.Node node = head;
         while (node != null) {
             // log.info(node.toString());
-            Assert.assertEquals(Ad[node.row][node.col], node.val);
+            assertEquals(Ad[node.row][node.col], node.val, 0.0);
             node = node.rowTail;
         }
         node = head;
         while (node != null) {
             // log.info(node.toString());
-            Assert.assertEquals(Ad[node.row][node.col], node.val);
+            assertEquals(Ad[node.row][node.col], node.val, 0.0);
             node = node.colTail;
         }
     }
@@ -118,10 +117,12 @@ public class LinkedSparseMatrixTest extends SparseMatrixTestAbstract {
         }
     }
 
+    @Test
     @Override
     public void testIteratorSet() {
     }
 
+    @Test
     @Override
     public void testIteratorSetGet() {
     }

--- a/src/test/java/no/uib/cipr/matrix/sparse/QMRDiagonalTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/QMRDiagonalTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.DiagonalPreconditioner;
-
 /**
  * Test QMR with diagonal preconditioning
  */
 public class QMRDiagonalTest extends QMRTest {
-
-    public QMRDiagonalTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/QMRILUTTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/QMRILUTTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.FlexCompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILUT;
-
 /**
  * Test of QMR with ILUT
  */
 public class QMRILUTTest extends QMRTest {
-
-    public QMRILUTTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/QMRILUTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/QMRILUTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,17 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.CompRowMatrix;
-import no.uib.cipr.matrix.sparse.ILU;
-
 /**
  * Test of QMR with ILU
  */
 public class QMRILUTest extends QMRTest {
-
-    public QMRILUTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/QMRTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/QMRTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -20,16 +20,10 @@
 
 package no.uib.cipr.matrix.sparse;
 
-import no.uib.cipr.matrix.sparse.QMR;
-
 /**
  * Test of QMR
  */
 public class QMRTest extends IterativeSolverTestAbstract {
-
-    public QMRTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createSolver() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/SPDIterativeSolverTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/SPDIterativeSolverTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -21,7 +21,6 @@
 package no.uib.cipr.matrix.sparse;
 
 import no.uib.cipr.matrix.SymmDenseEVD;
-import no.uib.cipr.matrix.sparse.FlexCompRowMatrix;
 import no.uib.cipr.matrix.Utilities;
 
 /**
@@ -30,10 +29,6 @@ import no.uib.cipr.matrix.Utilities;
 public abstract class SPDIterativeSolverTestAbstract
         extends
             IterativeSolverTestAbstract {
-
-    public SPDIterativeSolverTestAbstract(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createMatrix() throws Exception {

--- a/src/test/java/no/uib/cipr/matrix/sparse/SparseMatrixTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/SparseMatrixTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -21,6 +21,7 @@
 package no.uib.cipr.matrix.sparse;
 
 import no.uib.cipr.matrix.MatrixTestAbstract;
+import org.junit.Test;
 
 /**
  * Test of sparse matrices
@@ -29,25 +30,25 @@ public abstract class SparseMatrixTestAbstract extends MatrixTestAbstract {
 
     protected int bmax = 100, tmax = 10;
 
-    public SparseMatrixTestAbstract(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     @Override
     public void testMatrixSolve() {
         // Not applicable
     }
 
+    @Test
     @Override
     public void testTransMatrixSolve() {
         // Not applicable
     }
 
+    @Test
     @Override
     public void testTransVectorSolve() {
         // Not applicable
     }
 
+    @Test
     @Override
     public void testVectorSolve() {
         // Not applicable

--- a/src/test/java/no/uib/cipr/matrix/sparse/SparseStructImmutableMatrixTestAbstract.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/SparseStructImmutableMatrixTestAbstract.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -21,6 +21,7 @@
 package no.uib.cipr.matrix.sparse;
 
 import no.uib.cipr.matrix.StructImmutableMatrixTestAbstract;
+import org.junit.Test;
 
 /**
  * Test of sparse matrices whose sparsity structure is immutable
@@ -31,25 +32,25 @@ public abstract class SparseStructImmutableMatrixTestAbstract
 
     protected int bmax = 100, tmax = 10;
 
-    public SparseStructImmutableMatrixTestAbstract(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     @Override
     public void testMatrixSolve() {
         // Not applicable
     }
 
+    @Test
     @Override
     public void testTransMatrixSolve() {
         // Not applicable
     }
 
+    @Test
     @Override
     public void testTransVectorSolve() {
         // Not applicable
     }
 
+    @Test
     @Override
     public void testVectorSolve() {
         // Not applicable

--- a/src/test/java/no/uib/cipr/matrix/sparse/SparseVectorTest.java
+++ b/src/test/java/no/uib/cipr/matrix/sparse/SparseVectorTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2003-2006 Bjørn-Ove Heimsund
- * 
+ *
  * This file is part of MTJ.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by the
  * Free Software Foundation; either version 2.1 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, write to the Free Software Foundation,
  * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -28,15 +28,16 @@ import no.uib.cipr.matrix.Vector;
 import no.uib.cipr.matrix.Utilities;
 import no.uib.cipr.matrix.VectorEntry;
 import no.uib.cipr.matrix.VectorTestAbstract;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test of SparseVector
  */
 public class SparseVectorTest extends VectorTestAbstract {
-
-    public SparseVectorTest(String arg0) {
-        super(arg0);
-    }
 
     @Override
     protected void createPrimary() throws Exception {
@@ -46,6 +47,7 @@ public class SparseVectorTest extends VectorTestAbstract {
         xd = Utilities.populate(x, m);
     }
 
+    @Test
     public void testSparseVectorIndices() {
         /*
          * MTJ subtlety in getIndex() for SparseVector. before calling
@@ -82,6 +84,7 @@ public class SparseVectorTest extends VectorTestAbstract {
                 + index.length + ", with elements " + Arrays.toString(index);
     }
 
+    @Test
     public void testBug27() {
         double[] tfVector = {0.0, 0.5, 0.0, 0.4, 0.0};
         DenseVector dense = new DenseVector(tfVector, false);
@@ -102,6 +105,7 @@ public class SparseVectorTest extends VectorTestAbstract {
      * Unit test checking that the sparse vector does not end up ever using more
      * than "size" elements.
      */
+    @Test
     public void testOverAllocation() {
         for (int d = 0; d < 10; d++) {
             SparseVector v = new SparseVector(d, 0);
@@ -118,6 +122,7 @@ public class SparseVectorTest extends VectorTestAbstract {
         }
     }
 
+    @Test
     public void testGetRawIndex() {
         SparseVector vector = new SparseVector(Integer.MAX_VALUE);
         int[] index = vector.getRawIndex();
@@ -140,6 +145,7 @@ public class SparseVectorTest extends VectorTestAbstract {
         assertTrue(index.length > vector.getIndex().length);
     }
 
+    @Test
     public void testGetRawData() {
         SparseVector vector = new SparseVector(Integer.MAX_VALUE);
         double[] data = vector.getRawData();


### PR DESCRIPTION
Upgrade to fully use junit4, which uses annotations to mark tests and specify simple setup/teardown methods. More complex setup/teardown/interceptor patterns can be employed with [Rule](https://github.com/junit-team/junit/wiki/Rules#rules) and [ClassRule](https://github.com/junit-team/junit/wiki/Rules#classrule).

To test the upgrade, I counted the # of tests run before and after upgrade, which both total 2453.

It also appears my IDE removed some redundant whitespace, let me know if that is a problem and will replace it.

Command to count tests per class: `mvn clean test | grep '^Tests run:' | cut -d\  -f16 -f3'`
Example Output:
```
4, no.uib.cipr.matrix.BandCholeskyTest
3, no.uib.cipr.matrix.BandLUTest
61, no.uib.cipr.matrix.BandMatrixTest
4, no.uib.cipr.matrix.DenseCholeskyTest
4, no.uib.cipr.matrix.DenseLUTest
63, no.uib.cipr.matrix.DenseMatrixTest
23, no.uib.cipr.matrix.DenseVectorSubTest
23, no.uib.cipr.matrix.DenseVectorTest
2, no.uib.cipr.matrix.io.MatrixVectorIoTest
3, no.uib.cipr.matrix.KhatriRaoTest
61, no.uib.cipr.matrix.LowerSPDBandMatrixTest
61, no.uib.cipr.matrix.LowerSPDDenseMatrixTest
61, no.uib.cipr.matrix.LowerSPDPackMatrixTest
61, no.uib.cipr.matrix.LowerSymmBandMatrixTest
...
...
61, no.uib.cipr.matrix.UpperTriangDenseMatrixTest
61, no.uib.cipr.matrix.UpperTriangPackMatrixTest
2453,
```