### PR TITLE
Array designators [] should be on the type, not the variable

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/PermutationMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/PermutationMatrix.java
@@ -24,7 +24,7 @@ public class PermutationMatrix extends AbstractMatrix {
      * @param pivots
      *            using fortran (1-indexed) notation.
      */
-    public static PermutationMatrix fromPartialPivots(int pivots[]) {
+    public static PermutationMatrix fromPartialPivots(int[] pivots) {
         int[] permutations = new int[pivots.length];
         for (int i = 0; i < pivots.length; i++) {
             permutations[i] = i;
@@ -48,13 +48,13 @@ public class PermutationMatrix extends AbstractMatrix {
 
     // the instantaneous permutations to perform (zero-indexed)
     // http://en.wikipedia.org/wiki/Permutation_matrix
-    public PermutationMatrix(int permutations[]) {
+    public PermutationMatrix(int[] permutations) {
         this(permutations, null);
     }
 
     // permutations - instantaneous (zero-indexed)
     // pivots - sequential (fortran-indexed)
-    private PermutationMatrix(int permutations[], int pivots[]) {
+    private PermutationMatrix(int[] permutations, int[] pivots) {
         super(permutations.length, permutations.length);
         this.permutations = permutations;
         BitSet bitset = new BitSet();

--- a/src/main/java/no/uib/cipr/matrix/QRP.java
+++ b/src/main/java/no/uib/cipr/matrix/QRP.java
@@ -36,7 +36,7 @@ import org.netlib.util.intW;
 public class QRP {
 
     /** Pivoting vector */
-    int jpvt[];
+    int[] jpvt;
     /**
      * Scales for the reflectors
      */
@@ -86,8 +86,8 @@ public class QRP {
 
         int lwork1, lwork2;
         intW info = new intW(0);
-        double dummy[] = new double[1];
-        double ret[] = new double[1];
+        double[] dummy = new double[1];
+        double[] ret = new double[1];
 
         LAPACK lapack = LAPACK.getInstance();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1197 Array designators [] should be on the type, not the variable

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197 

Please let me know if you have any questions.

Zeeshan Asghar