### PR TITLE
String literals should not duplicated

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/AbstractMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/AbstractMatrix.java
@@ -60,6 +60,11 @@ import java.util.Iterator;
  */
 public abstract class AbstractMatrix implements Matrix {
 
+    private static final String A_NUM_COLUMNS_NOT_EQUALS_B_NUM_ROWS = "A.numColumns != B.numRows (";
+    private static final String B_NUM_COLUMNS_NOT_EQUALS_C_NUM_COLUMNS = "B.numColumns != C.numColumns (";
+    private static final String A_NUM_ROWS_NOT_EQUALS_C_NUM_ROWS = "A.numRows != C.numRows (";
+    private static final String A_IS_NOT_SQUARE = "!A.isSquare";
+
     /**
      * Number of rows
      */
@@ -224,7 +229,7 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkSolve(Vector b, Vector x) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (numRows != b.size())
             throw new IndexOutOfBoundsException("numRows != b.size (" + numRows
                     + " != " + b.size() + ")");
@@ -265,7 +270,7 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkRank1(Vector x, Vector y) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (x.size() != numRows)
             throw new IndexOutOfBoundsException("x.size != A.numRows ("
                     + x.size() + " != " + numRows + ")");
@@ -298,7 +303,7 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkRank2(Vector x, Vector y) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (x.size() != numRows)
             throw new IndexOutOfBoundsException("x.size != A.numRows ("
                     + x.size() + " != " + numRows + ")");
@@ -339,15 +344,17 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkMultAdd(Matrix B, Matrix C) {
         if (numRows != C.numRows())
-            throw new IndexOutOfBoundsException("A.numRows != C.numRows ("
-                    + numRows + " != " + C.numRows() + ")");
+            throw new IndexOutOfBoundsException(
+                    A_NUM_ROWS_NOT_EQUALS_C_NUM_ROWS + numRows + " != "
+                            + C.numRows() + ")");
         if (numColumns != B.numRows())
-            throw new IndexOutOfBoundsException("A.numColumns != B.numRows ("
-                    + numColumns + " != " + B.numRows() + ")");
+            throw new IndexOutOfBoundsException(
+                    A_NUM_COLUMNS_NOT_EQUALS_B_NUM_ROWS + numColumns + " != "
+                            + B.numRows() + ")");
         if (B.numColumns() != C.numColumns())
             throw new IndexOutOfBoundsException(
-                    "B.numColumns != C.numColumns (" + B.numColumns() + " != "
-                            + C.numColumns() + ")");
+                    B_NUM_COLUMNS_NOT_EQUALS_C_NUM_COLUMNS + B.numColumns()
+                            + " != " + C.numColumns() + ")");
     }
 
     public Matrix transAmult(Matrix B, Matrix C) {
@@ -390,8 +397,8 @@ public abstract class AbstractMatrix implements Matrix {
                     + numColumns + " != " + C.numRows() + ")");
         if (B.numColumns() != C.numColumns())
             throw new IndexOutOfBoundsException(
-                    "B.numColumns != C.numColumns (" + B.numColumns() + " != "
-                            + C.numColumns() + ")");
+                    B_NUM_COLUMNS_NOT_EQUALS_C_NUM_COLUMNS + B.numColumns()
+                            + " != " + C.numColumns() + ")");
     }
 
     public Matrix transBmult(Matrix B, Matrix C) {
@@ -431,8 +438,9 @@ public abstract class AbstractMatrix implements Matrix {
                     "A.numColumns != B.numColumns (" + numColumns + " != "
                             + B.numColumns() + ")");
         if (numRows != C.numRows())
-            throw new IndexOutOfBoundsException("A.numRows != C.numRows ("
-                    + numRows + " != " + C.numRows() + ")");
+            throw new IndexOutOfBoundsException(
+                    A_NUM_ROWS_NOT_EQUALS_C_NUM_ROWS + numRows + " != "
+                            + C.numRows() + ")");
         if (B.numRows() != C.numColumns())
             throw new IndexOutOfBoundsException("B.numRows != C.numColumns ("
                     + B.numRows() + " != " + C.numColumns() + ")");
@@ -495,7 +503,7 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkSolve(Matrix B, Matrix X) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (B.numRows() != numRows)
             throw new IndexOutOfBoundsException("B.numRows != A.numRows ("
                     + B.numRows() + " != " + numRows + ")");
@@ -526,10 +534,11 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkRank1(Matrix C) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (numRows != C.numRows())
-            throw new IndexOutOfBoundsException("A.numRows != C.numRows ("
-                    + numRows + " != " + C.numRows() + ")");
+            throw new IndexOutOfBoundsException(
+                    A_NUM_ROWS_NOT_EQUALS_C_NUM_ROWS + numRows + " != "
+                            + C.numRows() + ")");
     }
 
     public Matrix transRank1(Matrix C) {
@@ -550,7 +559,7 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkTransRank1(Matrix C) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (numRows != C.numColumns())
             throw new IndexOutOfBoundsException("A.numRows != C.numColumns ("
                     + numRows + " != " + C.numColumns() + ")");
@@ -574,14 +583,14 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkRank2(Matrix B, Matrix C) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (B.numRows() != C.numRows())
             throw new IndexOutOfBoundsException("B.numRows != C.numRows ("
                     + B.numRows() + " != " + C.numRows() + ")");
         if (B.numColumns() != C.numColumns())
             throw new IndexOutOfBoundsException(
-                    "B.numColumns != C.numColumns (" + B.numColumns() + " != "
-                            + C.numColumns() + ")");
+                    B_NUM_COLUMNS_NOT_EQUALS_C_NUM_COLUMNS + B.numColumns()
+                            + " != " + C.numColumns() + ")");
     }
 
     public Matrix transRank2(Matrix B, Matrix C) {
@@ -602,7 +611,7 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkTransRank2(Matrix B, Matrix C) {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
         if (numRows != B.numColumns())
             throw new IndexOutOfBoundsException("A.numRows != B.numColumns ("
                     + numRows + " != " + B.numColumns() + ")");
@@ -611,8 +620,8 @@ public abstract class AbstractMatrix implements Matrix {
                     + B.numRows() + " != " + C.numRows() + ")");
         if (B.numColumns() != C.numColumns())
             throw new IndexOutOfBoundsException(
-                    "B.numColumns != C.numColumns (" + B.numColumns() + " != "
-                            + C.numColumns() + ")");
+                    B_NUM_COLUMNS_NOT_EQUALS_C_NUM_COLUMNS + B.numColumns()
+                            + " != " + C.numColumns() + ")");
     }
 
     public Matrix scale(double alpha) {
@@ -692,7 +701,7 @@ public abstract class AbstractMatrix implements Matrix {
      */
     protected void checkTranspose() {
         if (!isSquare())
-            throw new IndexOutOfBoundsException("!A.isSquare");
+            throw new IndexOutOfBoundsException(A_IS_NOT_SQUARE);
     }
 
     public Matrix transpose(Matrix B) {
@@ -716,8 +725,9 @@ public abstract class AbstractMatrix implements Matrix {
             throw new IndexOutOfBoundsException("A.numRows != B.numColumns ("
                     + numRows + " != " + B.numColumns() + ")");
         if (numColumns != B.numRows())
-            throw new IndexOutOfBoundsException("A.numColumns != B.numRows ("
-                    + numColumns + " != " + B.numRows() + ")");
+            throw new IndexOutOfBoundsException(
+                    A_NUM_COLUMNS_NOT_EQUALS_B_NUM_ROWS + numColumns + " != "
+                            + B.numRows() + ")");
     }
 
     public double norm(Norm type) {

--- a/src/main/java/no/uib/cipr/matrix/io/MatrixVectorReader.java
+++ b/src/main/java/no/uib/cipr/matrix/io/MatrixVectorReader.java
@@ -33,6 +33,10 @@ import java.util.List;
  */
 public class MatrixVectorReader extends BufferedReader {
 
+    private static final String UNKNOWN_TOKEN_FOUND_DURING_PARSING = "Unknown token found during parsing";
+    private static final String END_OF_FILE_ENCOUNTERED_DURING_PARSING = "End-of-File encountered during parsing";
+    private static final String ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE = "All arrays must be of the same size";
+    private static final String MATRIX_MARKET = "%%MatrixMarket";
     /**
      * Reads the entries of the matrix or vector
      */
@@ -126,7 +130,7 @@ public class MatrixVectorReader extends BufferedReader {
                     "Current line unparsable. It must consist of 5 tokens");
 
         // Read header
-        if (!component[0].equalsIgnoreCase("%%MatrixMarket"))
+        if (!component[0].equalsIgnoreCase(MATRIX_MARKET))
             throw new IOException("Not in Matrix Market exchange format");
 
         // This will always be "matrix"
@@ -185,7 +189,7 @@ public class MatrixVectorReader extends BufferedReader {
                     "Current line unparsable. It must consist of 4 tokens");
 
         // Read header
-        if (!component[0].equalsIgnoreCase("%%MatrixMarket"))
+        if (!component[0].equalsIgnoreCase(MATRIX_MARKET))
             throw new IOException("Not in Matrix Market exchange format");
 
         // This will always be "vector"
@@ -230,7 +234,7 @@ public class MatrixVectorReader extends BufferedReader {
         String[] component = readTrimmedLine().split(" +");
         reset();
 
-        return component[0].equalsIgnoreCase("%%MatrixMarket");
+        return component[0].equalsIgnoreCase(MATRIX_MARKET);
     }
 
     /**
@@ -365,7 +369,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = dataR.length;
         if (size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             dataR[i] = getDouble();
             dataI[i] = getDouble();
@@ -380,7 +384,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = dataR.length;
         if (size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             dataR[i] = getFloat();
             dataI[i] = getFloat();
@@ -394,7 +398,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             index[i] = getInt();
             data[i] = getDouble();
@@ -408,7 +412,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             index[i] = getInt();
             data[i] = getFloat();
@@ -422,7 +426,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             index[i] = getInt();
             data[i] = getInt();
@@ -436,7 +440,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             index[i] = getInt();
             data[i] = getLong();
@@ -452,7 +456,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = index.length;
         if (size != dataR.length || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             index[i] = getInt();
             dataR[i] = getFloat();
@@ -469,7 +473,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = index.length;
         if (size != dataR.length || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             index[i] = getInt();
             dataR[i] = getDouble();
@@ -494,7 +498,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             row[i] = getInt();
             column[i] = getInt();
@@ -510,7 +514,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             row[i] = getInt();
             column[i] = getInt();
@@ -526,7 +530,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             row[i] = getInt();
             column[i] = getInt();
@@ -542,7 +546,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             row[i] = getInt();
             column[i] = getInt();
@@ -557,7 +561,7 @@ public class MatrixVectorReader extends BufferedReader {
         int size = row.length;
         if (size != column.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             row[i] = getInt();
             column[i] = getInt();
@@ -574,7 +578,7 @@ public class MatrixVectorReader extends BufferedReader {
         if (size != column.length || size != dataR.length
                 || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             row[i] = getInt();
             column[i] = getInt();
@@ -593,7 +597,7 @@ public class MatrixVectorReader extends BufferedReader {
         if (size != column.length || size != dataR.length
                 || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i) {
             row[i] = getInt();
             column[i] = getInt();
@@ -610,9 +614,9 @@ public class MatrixVectorReader extends BufferedReader {
         if (st.ttype == StreamTokenizer.TT_WORD)
             return Double.valueOf(st.sval).intValue();
         else if (st.ttype == StreamTokenizer.TT_EOF)
-            throw new EOFException("End-of-File encountered during parsing");
+            throw new EOFException(END_OF_FILE_ENCOUNTERED_DURING_PARSING);
         else
-            throw new IOException("Unknown token found during parsing");
+            throw new IOException(UNKNOWN_TOKEN_FOUND_DURING_PARSING);
     }
 
     /**
@@ -623,9 +627,9 @@ public class MatrixVectorReader extends BufferedReader {
         if (st.ttype == StreamTokenizer.TT_WORD)
             return Long.parseLong(st.sval);
         else if (st.ttype == StreamTokenizer.TT_EOF)
-            throw new EOFException("End-of-File encountered during parsing");
+            throw new EOFException(END_OF_FILE_ENCOUNTERED_DURING_PARSING);
         else
-            throw new IOException("Unknown token found during parsing");
+            throw new IOException(UNKNOWN_TOKEN_FOUND_DURING_PARSING);
     }
 
     /**
@@ -636,9 +640,9 @@ public class MatrixVectorReader extends BufferedReader {
         if (st.ttype == StreamTokenizer.TT_WORD)
             return Double.parseDouble(st.sval);
         else if (st.ttype == StreamTokenizer.TT_EOF)
-            throw new EOFException("End-of-File encountered during parsing");
+            throw new EOFException(END_OF_FILE_ENCOUNTERED_DURING_PARSING);
         else
-            throw new IOException("Unknown token found during parsing");
+            throw new IOException(UNKNOWN_TOKEN_FOUND_DURING_PARSING);
     }
 
     /**
@@ -649,9 +653,9 @@ public class MatrixVectorReader extends BufferedReader {
         if (st.ttype == StreamTokenizer.TT_WORD)
             return Float.parseFloat(st.sval);
         else if (st.ttype == StreamTokenizer.TT_EOF)
-            throw new EOFException("End-of-File encountered during parsing");
+            throw new EOFException(END_OF_FILE_ENCOUNTERED_DURING_PARSING);
         else
-            throw new IOException("Unknown token found during parsing");
+            throw new IOException(UNKNOWN_TOKEN_FOUND_DURING_PARSING);
     }
 
 }

--- a/src/main/java/no/uib/cipr/matrix/io/MatrixVectorWriter.java
+++ b/src/main/java/no/uib/cipr/matrix/io/MatrixVectorWriter.java
@@ -30,6 +30,8 @@ import java.util.Locale;
  */
 public class MatrixVectorWriter extends PrintWriter {
 
+    private static final String ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE = "All arrays must be of the same size";
+
     /**
      * Constructor for MatrixVectorWriter
      * 
@@ -155,7 +157,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = dataR.length;
         if (size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "% .12e % .12e\n", dataR[i], dataI[i]);
     }
@@ -168,7 +170,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = dataR.length;
         if (size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "% .12e % .12e\n", dataR[i], dataI[i]);
     }
@@ -198,7 +200,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d % .12e\n", index[i] + offset, data[i]);
     }
@@ -212,7 +214,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d % .12e\n", index[i] + offset, data[i]);
     }
@@ -226,7 +228,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d\n", index[i] + offset, data[i]);
     }
@@ -240,7 +242,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = index.length;
         if (size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d\n", index[i] + offset, data[i]);
     }
@@ -255,7 +257,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d % .12e\n", row[i] + offset,
                     column[i] + offset, data[i]);
@@ -271,7 +273,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d % .12e\n", row[i] + offset,
                     column[i] + offset, data[i]);
@@ -288,7 +290,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = index.length;
         if (size != dataR.length || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d % .12e % .12e\n", index[i] + offset,
                     dataR[i], dataI[i]);
@@ -305,7 +307,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = index.length;
         if (size != dataR.length || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d % .12e % .12e\n", index[i] + offset,
                     dataR[i], dataI[i]);
@@ -323,7 +325,7 @@ public class MatrixVectorWriter extends PrintWriter {
         if (size != column.length || size != dataR.length
                 || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d % .12e % .12e\n",
                     row[i] + offset, column[i] + offset, dataR[i], dataI[i]);
@@ -341,7 +343,7 @@ public class MatrixVectorWriter extends PrintWriter {
         if (size != column.length || size != dataR.length
                 || size != dataI.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d % .12e % .12e\n",
                     row[i] + offset, column[i] + offset, dataR[i], dataI[i]);
@@ -356,7 +358,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d %19d\n", row[i] + offset,
                     column[i] + offset, data[i]);
@@ -371,7 +373,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = row.length;
         if (size != column.length || size != data.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d %19d\n", row[i] + offset,
                     column[i] + offset, data[i]);
@@ -386,7 +388,7 @@ public class MatrixVectorWriter extends PrintWriter {
         int size = row.length;
         if (size != column.length)
             throw new IllegalArgumentException(
-                    "All arrays must be of the same size");
+                    ALL_ARRAYS_MUST_BE_OF_THE_SAME_SIZE);
         for (int i = 0; i < size; ++i)
             format(Locale.ENGLISH, "%10d %10d\n", row[i] + offset, column[i]
                     + offset);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1192 String literals should not duplicated

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1192 

Please let me know if you have any questions.

Zeeshan Asghar