### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/PermutationMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/PermutationMatrix.java
@@ -13,6 +13,30 @@ import java.util.BitSet;
  */
 public class PermutationMatrix extends AbstractMatrix {
 
+    private int[] permutations, pivots;
+    private boolean transposed;
+
+    // the instantaneous permutations to perform (zero-indexed)
+    // http://en.wikipedia.org/wiki/Permutation_matrix
+    public PermutationMatrix(int permutations[]) {
+        this(permutations, null);
+    }
+
+    // permutations - instantaneous (zero-indexed)
+    // pivots - sequential (fortran-indexed)
+    private PermutationMatrix(int permutations[], int pivots[]) {
+        super(permutations.length, permutations.length);
+        this.permutations = permutations;
+        BitSet bitset = new BitSet();
+        for (int i : permutations) {
+            if (bitset.get(i))
+                throw new IllegalArgumentException("non-unique permutations: "
+                        + i);
+            bitset.set(i);
+        }
+        this.pivots = pivots;
+    }
+
     /**
      * The sequential row permutations to perform, e.g. (2, 3, 3) means: permute
      * row 1 with row 2, then permute row 2 with row 3, then permute row 3 with
@@ -40,31 +64,6 @@ public class PermutationMatrix extends AbstractMatrix {
         }
 
         return new PermutationMatrix(permutations, pivots);
-    }
-
-    private int[] permutations, pivots;
-
-    private boolean transposed;
-
-    // the instantaneous permutations to perform (zero-indexed)
-    // http://en.wikipedia.org/wiki/Permutation_matrix
-    public PermutationMatrix(int[] permutations) {
-        this(permutations, null);
-    }
-
-    // permutations - instantaneous (zero-indexed)
-    // pivots - sequential (fortran-indexed)
-    private PermutationMatrix(int[] permutations, int[] pivots) {
-        super(permutations.length, permutations.length);
-        this.permutations = permutations;
-        BitSet bitset = new BitSet();
-        for (int i : permutations) {
-            if (bitset.get(i))
-                throw new IllegalArgumentException("non-unique permutations: "
-                        + i);
-            bitset.set(i);
-        }
-        this.pivots = pivots;
     }
 
     @Override

--- a/src/main/java/no/uib/cipr/matrix/sparse/CompColMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/CompColMatrix.java
@@ -60,6 +60,30 @@ public class CompColMatrix extends AbstractMatrix {
     /**
      * Constructor for CompColMatrix
      * 
+     * @param A
+     *            Copies from this matrix
+     * @param deep
+     *            True if the copy is to be deep. If it is a shallow copy,
+     *            <code>A</code> must be a <code>CompColMatrix</code>
+     */
+    public CompColMatrix(Matrix A, boolean deep) {
+        super(A);
+        construct(A, deep);
+    }
+
+    /**
+     * Constructor for CompColMatrix
+     * 
+     * @param A
+     *            Copies from this matrix. The copy will be deep
+     */
+    public CompColMatrix(Matrix A) {
+        this(A, true);
+    }
+
+    /**
+     * Constructor for CompColMatrix
+     * 
      * @param r
      *            Reader to get sparse matrix from
      */
@@ -226,30 +250,6 @@ public class CompColMatrix extends AbstractMatrix {
             rowIndex = Ac.getRowIndices();
             data = Ac.getData();
         }
-    }
-
-    /**
-     * Constructor for CompColMatrix
-     * 
-     * @param A
-     *            Copies from this matrix
-     * @param deep
-     *            True if the copy is to be deep. If it is a shallow copy,
-     *            <code>A</code> must be a <code>CompColMatrix</code>
-     */
-    public CompColMatrix(Matrix A, boolean deep) {
-        super(A);
-        construct(A, deep);
-    }
-
-    /**
-     * Constructor for CompColMatrix
-     * 
-     * @param A
-     *            Copies from this matrix. The copy will be deep
-     */
-    public CompColMatrix(Matrix A) {
-        this(A, true);
     }
 
     /**

--- a/src/main/java/no/uib/cipr/matrix/sparse/CompDiagMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/CompDiagMatrix.java
@@ -53,6 +53,57 @@ public class CompDiagMatrix extends AbstractMatrix {
     int[] ind;
 
     /**
+     * Creates a new sparse matrix without preallocation
+     */
+    public CompDiagMatrix(int numRows, int numColumns) {
+        this(numRows, numColumns, new int[0]);
+    }
+
+    /**
+     * Creates a new sparse matrix copied from the given matrix. Can take a deep
+     * copy or a shallow copy. For the latter, the supplied matrix must be a
+     * CompDiagMatrix. Preallocation is also possible, but is only used for the
+     * deep copy.
+     */
+    public CompDiagMatrix(Matrix A, int[] diagonal, boolean deep) {
+        super(A);
+
+        if (deep) {
+            construct(diagonal);
+            set(A);
+        } else {
+            CompDiagMatrix Ac = (CompDiagMatrix) A;
+            diag = Ac.getDiagonals();
+            ind = Ac.getIndex();
+        }
+    }
+
+    /**
+     * Creates a new sparse matrix copied from the given matrix. Takes a deep
+     * copy, with possibility to specify preallocation
+     */
+    public CompDiagMatrix(Matrix A, int[] diagonal) {
+        this(A, diagonal, true);
+    }
+
+    /**
+     * Creates a new sparse matrix copied from the given matrix. Can take a deep
+     * copy or a shallow copy. For the latter, the supplied matrix must be a
+     * CompDiagMatrix. No preallocation is done
+     */
+    public CompDiagMatrix(Matrix A, boolean deep) {
+        this(A, new int[0], deep);
+    }
+
+    /**
+     * Creates a new sparse matrix copied from the given matrix. Takes a deep
+     * copy without preallocation
+     */
+    public CompDiagMatrix(Matrix A) {
+        this(A, new int[0], true);
+    }
+
+    /**
      * Constructor for CompDiagMatrix
      * 
      * @param r
@@ -158,57 +209,6 @@ public class CompDiagMatrix extends AbstractMatrix {
             ind[i] = sortedDiagonal[i];
             diag[i] = new double[getDiagSize(sortedDiagonal[i])];
         }
-    }
-
-    /**
-     * Creates a new sparse matrix without preallocation
-     */
-    public CompDiagMatrix(int numRows, int numColumns) {
-        this(numRows, numColumns, new int[0]);
-    }
-
-    /**
-     * Creates a new sparse matrix copied from the given matrix. Can take a deep
-     * copy or a shallow copy. For the latter, the supplied matrix must be a
-     * CompDiagMatrix. Preallocation is also possible, but is only used for the
-     * deep copy.
-     */
-    public CompDiagMatrix(Matrix A, int[] diagonal, boolean deep) {
-        super(A);
-
-        if (deep) {
-            construct(diagonal);
-            set(A);
-        } else {
-            CompDiagMatrix Ac = (CompDiagMatrix) A;
-            diag = Ac.getDiagonals();
-            ind = Ac.getIndex();
-        }
-    }
-
-    /**
-     * Creates a new sparse matrix copied from the given matrix. Takes a deep
-     * copy, with possibility to specify preallocation
-     */
-    public CompDiagMatrix(Matrix A, int[] diagonal) {
-        this(A, diagonal, true);
-    }
-
-    /**
-     * Creates a new sparse matrix copied from the given matrix. Can take a deep
-     * copy or a shallow copy. For the latter, the supplied matrix must be a
-     * CompDiagMatrix. No preallocation is done
-     */
-    public CompDiagMatrix(Matrix A, boolean deep) {
-        this(A, new int[0], deep);
-    }
-
-    /**
-     * Creates a new sparse matrix copied from the given matrix. Takes a deep
-     * copy without preallocation
-     */
-    public CompDiagMatrix(Matrix A) {
-        this(A, new int[0], true);
     }
 
     /**

--- a/src/main/java/no/uib/cipr/matrix/sparse/CompRowMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/CompRowMatrix.java
@@ -53,6 +53,30 @@ public class CompRowMatrix extends AbstractMatrix {
     /**
      * Constructor for CompRowMatrix
      * 
+     * @param A
+     *            Copies from this matrix
+     * @param deep
+     *            True if the copy is to be deep. If it is a shallow copy,
+     *            <code>A</code> must be a <code>CompRowMatrix</code>
+     */
+    public CompRowMatrix(Matrix A, boolean deep) {
+        super(A);
+        construct(A, deep);
+    }
+
+    /**
+     * Constructor for CompRowMatrix
+     * 
+     * @param A
+     *            Copies from this matrix. The copy will be deep
+     */
+    public CompRowMatrix(Matrix A) {
+        this(A, true);
+    }
+
+    /**
+     * Constructor for CompRowMatrix
+     * 
      * @param r
      *            Reader to get sparse matrix from
      */
@@ -220,30 +244,6 @@ public class CompRowMatrix extends AbstractMatrix {
             rowPointer = Ac.getRowPointers();
             data = Ac.getData();
         }
-    }
-
-    /**
-     * Constructor for CompRowMatrix
-     * 
-     * @param A
-     *            Copies from this matrix
-     * @param deep
-     *            True if the copy is to be deep. If it is a shallow copy,
-     *            <code>A</code> must be a <code>CompRowMatrix</code>
-     */
-    public CompRowMatrix(Matrix A, boolean deep) {
-        super(A);
-        construct(A, deep);
-    }
-
-    /**
-     * Constructor for CompRowMatrix
-     * 
-     * @param A
-     *            Copies from this matrix. The copy will be deep
-     */
-    public CompRowMatrix(Matrix A) {
-        this(A, true);
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213  The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Zeeshan Asghar