### PR TITLE
Better doc and exceptions for fixed CompMatrices

### DIFF
--- a/src/main/java/no/uib/cipr/matrix/sparse/Arrays.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/Arrays.java
@@ -114,7 +114,7 @@ class Arrays {
      *            Start posisiton in the index
      * @param end
      *            One past the end position in the index
-     * @return Integer index to key. -1 if not found
+     * @return Integer index to key. A negative integer if not found
      */
     public static int binarySearch(int[] index, int key, int begin, int end) {
         return java.util.Arrays.binarySearch(index, begin, end, key);

--- a/src/main/java/no/uib/cipr/matrix/sparse/CompColMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/CompColMatrix.java
@@ -38,7 +38,10 @@ import no.uib.cipr.matrix.io.MatrixSize;
 import no.uib.cipr.matrix.io.MatrixVectorReader;
 
 /**
- * Compressed column storage (CCS) matrix
+ * Compressed column storage (CCS) matrix.
+ * 
+ * Only use this class if the matrix structure (the location of nonzeros) is
+ * known and static (does not change).
  */
 public class CompColMatrix extends AbstractMatrix {
 
@@ -371,7 +374,7 @@ public class CompColMatrix extends AbstractMatrix {
         int i = no.uib.cipr.matrix.sparse.Arrays.binarySearch(rowIndex, row,
                 columnPointer[column], columnPointer[column + 1]);
 
-        if (i != -1 && rowIndex[i] == row)
+        if (i >= 0 && rowIndex[i] == row)
             return i;
         else
             throw new IndexOutOfBoundsException("Entry (" + (row + 1) + ", "

--- a/src/main/java/no/uib/cipr/matrix/sparse/CompRowMatrix.java
+++ b/src/main/java/no/uib/cipr/matrix/sparse/CompRowMatrix.java
@@ -31,7 +31,10 @@ import java.util.*;
 import java.util.Arrays;
 
 /**
- * Compressed row storage (CRS) matrix
+ * Compressed row storage (CRS) matrix.
+ * 
+ * Only use this class if the matrix structure (the location of nonzeros) is
+ * known and static (does not change).
  */
 public class CompRowMatrix extends AbstractMatrix {
 
@@ -420,7 +423,7 @@ public class CompRowMatrix extends AbstractMatrix {
         int i = no.uib.cipr.matrix.sparse.Arrays.binarySearch(columnIndex,
                 column, rowPointer[row], rowPointer[row + 1]);
 
-        if (i != -1 && columnIndex[i] == column)
+        if (i >= 0 && columnIndex[i] == column)
             return i;
         else
             throw new IndexOutOfBoundsException("Entry (" + (row + 1) + ", "


### PR DESCRIPTION
`getIndex` throws NullPointerExceptions when the Comp{Row,Col}Matrix
classes change their nonzero structure.
This is due to `Arrays.binarySearch` returning an int < -1.
This fix provides better documentation and handles this case.